### PR TITLE
Tree shaking

### DIFF
--- a/examples/browser/main.ts
+++ b/examples/browser/main.ts
@@ -4,7 +4,9 @@ import * as WebKit from '../../out/WebKit';
 
 function makeButton(label: string, callback) {
     let but = new Gtk.Button({ label: label })
-    but.get_child().modify_font(FontDescription.from_string('sans bold 16'))
+    const child = but.get_child()
+    if(!child) throw new Error('Gtk.Button child is undefined')
+    child.modify_font(FontDescription.from_string('sans bold 16'))
     but.connect("clicked", (obj) => { callback() })
     return but
 }

--- a/examples/editor/main.ts
+++ b/examples/editor/main.ts
@@ -1,6 +1,6 @@
 import * as Gtk from '../../out/Gtk';
 import * as GtkSource from '../../out/GtkSource'
-import { giCast } from '../../out/cast'
+import * as giCast from '../../out/cast'
 
 Gtk.init(null)
 
@@ -15,7 +15,7 @@ srcView.monospace = true
 
 // Unfortunately the "buffer" property is not GtkSource.Buffer so we need to downcast
 // it. giCast gives us a type-check at runtime.
-let buf: GtkSource.Buffer = giCast<GtkSource.Buffer>(srcView.buffer, GtkSource.Buffer)
+let buf: GtkSource.Buffer = giCast.GtkSource_Buffer(srcView.buffer)
 let lang = GtkSource.LanguageManager.get_default().get_language("js")
 buf.set_language(lang)
 

--- a/examples/editor/webpack.config.js
+++ b/examples/editor/webpack.config.js
@@ -1,4 +1,8 @@
-module.exports = {
+const path = require('path')
+const webpack = require('webpack')
+const MinifyPlugin = require('babel-minify-webpack-plugin')
+
+module.exports = env => ({
   entry: ['./main.ts' ],
   output: {
     filename: 'editor.js',
@@ -12,7 +16,10 @@ module.exports = {
       }
     ]
   },
+  plugins: env === 'production'
+    ? [ new MinifyPlugin({}, { comments: false }) ]
+    : [],
   resolve: {
     extensions: [".tsx", ".ts", ".js"]
   }
-};
+})

--- a/out/AppIndicator3.d.ts
+++ b/out/AppIndicator3.d.ts
@@ -97,9 +97,9 @@ export interface Indicator {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -108,21 +108,21 @@ export interface Indicator {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of AppIndicator3.Indicator */
-    vfunc_connection_changed(connected: boolean, user_data: object): void
-    vfunc_new_attention_icon(user_data: object): void
-    vfunc_new_icon(user_data: object): void
-    vfunc_new_icon_theme_path(icon_theme_path: string, user_data: object): void
-    vfunc_new_label(label: string, guide: string, user_data: object): void
-    vfunc_new_status(status: string, user_data: object): void
-    vfunc_scroll_event(delta: number, direction: Gdk.ScrollDirection, user_data: object): void
+    vfunc_connection_changed(connected: boolean, user_data: object | null): void
+    vfunc_new_attention_icon(user_data: object | null): void
+    vfunc_new_icon(user_data: object | null): void
+    vfunc_new_icon_theme_path(icon_theme_path: string, user_data: object | null): void
+    vfunc_new_label(label: string, guide: string, user_data: object | null): void
+    vfunc_new_status(status: string, user_data: object | null): void
+    vfunc_scroll_event(delta: number, direction: Gdk.ScrollDirection, user_data: object | null): void
     vfunc_unfallback(status_icon: Gtk.StatusIcon): void
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void

--- a/out/Atk.d.ts
+++ b/out/Atk.d.ts
@@ -338,10 +338,10 @@ export interface FocusHandler {
     (object: Object, focus_in: boolean): void
 }
 export interface Function {
-    (user_data: object): boolean
+    (user_data: object | null): boolean
 }
 export interface KeySnoopFunc {
-    (event: KeyEventStruct, user_data: object): number
+    (event: KeyEventStruct, user_data: object | null): number
 }
 export interface PropertyChangeHandler {
     (obj: Object, vals: PropertyValues): void
@@ -372,11 +372,11 @@ export interface Component {
     /* Methods of Atk.Component */
     contains(x: number, y: number, coord_type: CoordType): boolean
     get_alpha(): number
-    get_extents(x: number, y: number, width: number, height: number, coord_type: CoordType): void
+    get_extents(coord_type: CoordType): [ /* x */ number | null, /* y */ number | null, /* width */ number | null, /* height */ number | null ]
     get_layer(): Layer
     get_mdi_zorder(): number
-    get_position(x: number, y: number, coord_type: CoordType): void
-    get_size(width: number, height: number): void
+    get_position(coord_type: CoordType): [ /* x */ number | null, /* y */ number | null ]
+    get_size(): [ /* width */ number | null, /* height */ number | null ]
     grab_focus(): boolean
     ref_accessible_at_point(x: number, y: number, coord_type: CoordType): Object | null
     remove_focus_handler(handler_id: number): void
@@ -387,11 +387,11 @@ export interface Component {
     vfunc_bounds_changed(bounds: Rectangle): void
     vfunc_contains(x: number, y: number, coord_type: CoordType): boolean
     vfunc_get_alpha(): number
-    vfunc_get_extents(x: number, y: number, width: number, height: number, coord_type: CoordType): void
+    vfunc_get_extents(coord_type: CoordType): [ /* x */ number | null, /* y */ number | null, /* width */ number | null, /* height */ number | null ]
     vfunc_get_layer(): Layer
     vfunc_get_mdi_zorder(): number
-    vfunc_get_position(x: number, y: number, coord_type: CoordType): void
-    vfunc_get_size(width: number, height: number): void
+    vfunc_get_position(coord_type: CoordType): [ /* x */ number | null, /* y */ number | null ]
+    vfunc_get_size(): [ /* width */ number | null, /* height */ number | null ]
     vfunc_grab_focus(): boolean
     vfunc_ref_accessible_at_point(x: number, y: number, coord_type: CoordType): Object | null
     vfunc_remove_focus_handler(handler_id: number): void
@@ -410,14 +410,14 @@ export interface Document {
     get_attribute_value(attribute_name: string): string | null
     get_attributes(): AttributeSet
     get_current_page_number(): number
-    get_document(): object
+    get_document(): object | null
     get_document_type(): string
     get_locale(): string
     get_page_count(): number
     set_attribute_value(attribute_name: string, attribute_value: string): boolean
     /* Virtual methods of Atk.Document */
     vfunc_get_current_page_number(): number
-    vfunc_get_document(): object
+    vfunc_get_document(): object | null
     vfunc_get_document_attribute_value(attribute_name: string): string
     vfunc_get_document_locale(): string
     vfunc_get_document_type(): string
@@ -486,14 +486,14 @@ export interface Image {
     /* Methods of Atk.Image */
     get_image_description(): string
     get_image_locale(): string | null
-    get_image_position(x: number, y: number, coord_type: CoordType): void
-    get_image_size(width: number, height: number): void
+    get_image_position(coord_type: CoordType): [ /* x */ number | null, /* y */ number | null ]
+    get_image_size(): [ /* width */ number | null, /* height */ number | null ]
     set_image_description(description: string): boolean
     /* Virtual methods of Atk.Image */
     vfunc_get_image_description(): string
     vfunc_get_image_locale(): string | null
-    vfunc_get_image_position(x: number, y: number, coord_type: CoordType): void
-    vfunc_get_image_size(width: number, height: number): void
+    vfunc_get_image_position(coord_type: CoordType): [ /* x */ number | null, /* y */ number | null ]
+    vfunc_get_image_size(): [ /* width */ number | null, /* height */ number | null ]
     vfunc_set_image_description(description: string): boolean
 }
 export interface Image_Static {
@@ -657,11 +657,11 @@ export interface Text {
     get_caret_offset(): number
     get_character_at_offset(offset: number): number
     get_character_count(): number
-    get_character_extents(offset: number, x: number, y: number, width: number, height: number, coords: CoordType): void
+    get_character_extents(offset: number, coords: CoordType): [ /* x */ number | null, /* y */ number | null, /* width */ number | null, /* height */ number | null ]
     get_default_attributes(): AttributeSet
     get_n_selections(): number
     get_offset_at_point(x: number, y: number, coords: CoordType): number
-    get_range_extents(start_offset: number, end_offset: number, coord_type: CoordType, rect: TextRectangle): void
+    get_range_extents(start_offset: number, end_offset: number, coord_type: CoordType): /* rect */ TextRectangle
     get_run_attributes(offset: number): [ /* returnType */ AttributeSet, /* start_offset */ number, /* end_offset */ number ]
     get_selection(selection_num: number): [ /* returnType */ string, /* start_offset */ number, /* end_offset */ number ]
     get_string_at_offset(offset: number, granularity: TextGranularity): [ /* returnType */ string | null, /* start_offset */ number, /* end_offset */ number ]
@@ -678,11 +678,11 @@ export interface Text {
     vfunc_get_caret_offset(): number
     vfunc_get_character_at_offset(offset: number): number
     vfunc_get_character_count(): number
-    vfunc_get_character_extents(offset: number, x: number, y: number, width: number, height: number, coords: CoordType): void
+    vfunc_get_character_extents(offset: number, coords: CoordType): [ /* x */ number | null, /* y */ number | null, /* width */ number | null, /* height */ number | null ]
     vfunc_get_default_attributes(): AttributeSet
     vfunc_get_n_selections(): number
     vfunc_get_offset_at_point(x: number, y: number, coords: CoordType): number
-    vfunc_get_range_extents(start_offset: number, end_offset: number, coord_type: CoordType, rect: TextRectangle): void
+    vfunc_get_range_extents(start_offset: number, end_offset: number, coord_type: CoordType): /* rect */ TextRectangle
     vfunc_get_run_attributes(offset: number): [ /* returnType */ AttributeSet, /* start_offset */ number, /* end_offset */ number ]
     vfunc_get_selection(selection_num: number): [ /* returnType */ string, /* start_offset */ number, /* end_offset */ number ]
     vfunc_get_string_at_offset(offset: number, granularity: TextGranularity): [ /* returnType */ string | null, /* start_offset */ number, /* end_offset */ number ]
@@ -714,22 +714,22 @@ export declare class Text_Static {
 export declare var Text: Text_Static
 export interface Value {
     /* Methods of Atk.Value */
-    get_current_value(value: any): void
+    get_current_value(): /* value */ any
     get_increment(): number
-    get_maximum_value(value: any): void
-    get_minimum_increment(value: any): void
-    get_minimum_value(value: any): void
+    get_maximum_value(): /* value */ any
+    get_minimum_increment(): /* value */ any
+    get_minimum_value(): /* value */ any
     get_range(): Range | null
     get_sub_ranges(): GLib.SList
     get_value_and_text(): [ /* value */ number, /* text */ string | null ]
     set_current_value(value: any): boolean
     set_value(new_value: number): void
     /* Virtual methods of Atk.Value */
-    vfunc_get_current_value(value: any): void
+    vfunc_get_current_value(): /* value */ any
     vfunc_get_increment(): number
-    vfunc_get_maximum_value(value: any): void
-    vfunc_get_minimum_increment(value: any): void
-    vfunc_get_minimum_value(value: any): void
+    vfunc_get_maximum_value(): /* value */ any
+    vfunc_get_minimum_increment(): /* value */ any
+    vfunc_get_minimum_value(): /* value */ any
     vfunc_get_range(): Range | null
     vfunc_get_sub_ranges(): GLib.SList
     vfunc_get_value_and_text(): [ /* value */ number, /* text */ string | null ]
@@ -801,7 +801,7 @@ export interface GObjectAccessible {
     get_object_locale(): string
     get_parent(): Object
     get_role(): Role
-    initialize(data: object): void
+    initialize(data: object | null): void
     notify_state_change(state: State, value: boolean): void
     peek_parent(): Object
     ref_accessible_child(i: number): Object
@@ -818,9 +818,9 @@ export interface GObjectAccessible {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -829,16 +829,16 @@ export interface GObjectAccessible {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Atk.Object */
-    vfunc_active_descendant_changed(child: object): void
-    vfunc_children_changed(change_index: number, changed_child: object): void
+    vfunc_active_descendant_changed(child: object | null): void
+    vfunc_children_changed(change_index: number, changed_child: object | null): void
     vfunc_focus_event(focus_in: boolean): void
     vfunc_get_attributes(): AttributeSet
     vfunc_get_description(): string
@@ -850,7 +850,7 @@ export interface GObjectAccessible {
     vfunc_get_object_locale(): string
     vfunc_get_parent(): Object
     vfunc_get_role(): Role
-    vfunc_initialize(data: object): void
+    vfunc_initialize(data: object | null): void
     vfunc_property_change(values: PropertyValues): void
     vfunc_ref_relation_set(): RelationSet
     vfunc_ref_state_set(): StateSet
@@ -870,10 +870,10 @@ export interface GObjectAccessible {
     vfunc_notify(pspec: GObject.ParamSpec): void
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Atk.Object */
-    connect(sigName: "active-descendant-changed", callback: ((obj: GObjectAccessible, arg1: object) => void))
-    connect(sigName: "children-changed", callback: ((obj: GObjectAccessible, arg1: number, arg2: object) => void))
+    connect(sigName: "active-descendant-changed", callback: ((obj: GObjectAccessible, arg1: object | null) => void))
+    connect(sigName: "children-changed", callback: ((obj: GObjectAccessible, arg1: number, arg2: object | null) => void))
     connect(sigName: "focus-event", callback: ((obj: GObjectAccessible, arg1: boolean) => void))
-    connect(sigName: "property-change", callback: ((obj: GObjectAccessible, arg1: object) => void))
+    connect(sigName: "property-change", callback: ((obj: GObjectAccessible, arg1: object | null) => void))
     connect(sigName: "state-change", callback: ((obj: GObjectAccessible, arg1: string, arg2: boolean) => void))
     connect(sigName: "visible-data-changed", callback: ((obj: GObjectAccessible) => void))
     /* Signals of GObject.Object */
@@ -928,9 +928,9 @@ export interface Hyperlink {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -939,10 +939,10 @@ export interface Hyperlink {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -993,9 +993,9 @@ export interface Misc {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1004,10 +1004,10 @@ export interface Misc {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1074,7 +1074,7 @@ export interface NoOpObject {
     get_object_locale(): string
     get_parent(): Object
     get_role(): Role
-    initialize(data: object): void
+    initialize(data: object | null): void
     notify_state_change(state: State, value: boolean): void
     peek_parent(): Object
     ref_accessible_child(i: number): Object
@@ -1091,9 +1091,9 @@ export interface NoOpObject {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1102,16 +1102,16 @@ export interface NoOpObject {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Atk.Object */
-    vfunc_active_descendant_changed(child: object): void
-    vfunc_children_changed(change_index: number, changed_child: object): void
+    vfunc_active_descendant_changed(child: object | null): void
+    vfunc_children_changed(change_index: number, changed_child: object | null): void
     vfunc_focus_event(focus_in: boolean): void
     vfunc_get_attributes(): AttributeSet
     vfunc_get_description(): string
@@ -1123,7 +1123,7 @@ export interface NoOpObject {
     vfunc_get_object_locale(): string
     vfunc_get_parent(): Object
     vfunc_get_role(): Role
-    vfunc_initialize(data: object): void
+    vfunc_initialize(data: object | null): void
     vfunc_property_change(values: PropertyValues): void
     vfunc_ref_relation_set(): RelationSet
     vfunc_ref_state_set(): StateSet
@@ -1143,10 +1143,10 @@ export interface NoOpObject {
     vfunc_notify(pspec: GObject.ParamSpec): void
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Atk.Object */
-    connect(sigName: "active-descendant-changed", callback: ((obj: NoOpObject, arg1: object) => void))
-    connect(sigName: "children-changed", callback: ((obj: NoOpObject, arg1: number, arg2: object) => void))
+    connect(sigName: "active-descendant-changed", callback: ((obj: NoOpObject, arg1: object | null) => void))
+    connect(sigName: "children-changed", callback: ((obj: NoOpObject, arg1: number, arg2: object | null) => void))
     connect(sigName: "focus-event", callback: ((obj: NoOpObject, arg1: boolean) => void))
-    connect(sigName: "property-change", callback: ((obj: NoOpObject, arg1: object) => void))
+    connect(sigName: "property-change", callback: ((obj: NoOpObject, arg1: object | null) => void))
     connect(sigName: "state-change", callback: ((obj: NoOpObject, arg1: string, arg2: boolean) => void))
     connect(sigName: "visible-data-changed", callback: ((obj: NoOpObject) => void))
     /* Signals of GObject.Object */
@@ -1192,9 +1192,9 @@ export interface NoOpObjectFactory {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1203,10 +1203,10 @@ export interface NoOpObjectFactory {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1283,7 +1283,7 @@ export interface Object {
     get_object_locale(): string
     get_parent(): Object
     get_role(): Role
-    initialize(data: object): void
+    initialize(data: object | null): void
     notify_state_change(state: State, value: boolean): void
     peek_parent(): Object
     ref_accessible_child(i: number): Object
@@ -1300,9 +1300,9 @@ export interface Object {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1311,16 +1311,16 @@ export interface Object {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Atk.Object */
-    vfunc_active_descendant_changed(child: object): void
-    vfunc_children_changed(change_index: number, changed_child: object): void
+    vfunc_active_descendant_changed(child: object | null): void
+    vfunc_children_changed(change_index: number, changed_child: object | null): void
     vfunc_focus_event(focus_in: boolean): void
     vfunc_get_attributes(): AttributeSet
     vfunc_get_description(): string
@@ -1332,7 +1332,7 @@ export interface Object {
     vfunc_get_object_locale(): string
     vfunc_get_parent(): Object
     vfunc_get_role(): Role
-    vfunc_initialize(data: object): void
+    vfunc_initialize(data: object | null): void
     vfunc_property_change(values: PropertyValues): void
     vfunc_ref_relation_set(): RelationSet
     vfunc_ref_state_set(): StateSet
@@ -1352,10 +1352,10 @@ export interface Object {
     vfunc_notify(pspec: GObject.ParamSpec): void
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Atk.Object */
-    connect(sigName: "active-descendant-changed", callback: ((obj: Object, arg1: object) => void))
-    connect(sigName: "children-changed", callback: ((obj: Object, arg1: number, arg2: object) => void))
+    connect(sigName: "active-descendant-changed", callback: ((obj: Object, arg1: object | null) => void))
+    connect(sigName: "children-changed", callback: ((obj: Object, arg1: number, arg2: object | null) => void))
     connect(sigName: "focus-event", callback: ((obj: Object, arg1: boolean) => void))
-    connect(sigName: "property-change", callback: ((obj: Object, arg1: object) => void))
+    connect(sigName: "property-change", callback: ((obj: Object, arg1: object | null) => void))
     connect(sigName: "state-change", callback: ((obj: Object, arg1: string, arg2: boolean) => void))
     connect(sigName: "visible-data-changed", callback: ((obj: Object) => void))
     /* Signals of GObject.Object */
@@ -1397,9 +1397,9 @@ export interface ObjectFactory {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1408,10 +1408,10 @@ export interface ObjectFactory {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1476,7 +1476,7 @@ export interface Plug {
     get_object_locale(): string
     get_parent(): Object
     get_role(): Role
-    initialize(data: object): void
+    initialize(data: object | null): void
     notify_state_change(state: State, value: boolean): void
     peek_parent(): Object
     ref_accessible_child(i: number): Object
@@ -1493,9 +1493,9 @@ export interface Plug {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1504,18 +1504,18 @@ export interface Plug {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Atk.Plug */
     vfunc_get_object_id(): string
     /* Virtual methods of Atk.Object */
-    vfunc_active_descendant_changed(child: object): void
-    vfunc_children_changed(change_index: number, changed_child: object): void
+    vfunc_active_descendant_changed(child: object | null): void
+    vfunc_children_changed(change_index: number, changed_child: object | null): void
     vfunc_focus_event(focus_in: boolean): void
     vfunc_get_attributes(): AttributeSet
     vfunc_get_description(): string
@@ -1527,7 +1527,7 @@ export interface Plug {
     vfunc_get_object_locale(): string
     vfunc_get_parent(): Object
     vfunc_get_role(): Role
-    vfunc_initialize(data: object): void
+    vfunc_initialize(data: object | null): void
     vfunc_property_change(values: PropertyValues): void
     vfunc_ref_relation_set(): RelationSet
     vfunc_ref_state_set(): StateSet
@@ -1547,10 +1547,10 @@ export interface Plug {
     vfunc_notify(pspec: GObject.ParamSpec): void
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Atk.Object */
-    connect(sigName: "active-descendant-changed", callback: ((obj: Plug, arg1: object) => void))
-    connect(sigName: "children-changed", callback: ((obj: Plug, arg1: number, arg2: object) => void))
+    connect(sigName: "active-descendant-changed", callback: ((obj: Plug, arg1: object | null) => void))
+    connect(sigName: "children-changed", callback: ((obj: Plug, arg1: number, arg2: object | null) => void))
     connect(sigName: "focus-event", callback: ((obj: Plug, arg1: boolean) => void))
-    connect(sigName: "property-change", callback: ((obj: Plug, arg1: object) => void))
+    connect(sigName: "property-change", callback: ((obj: Plug, arg1: object | null) => void))
     connect(sigName: "state-change", callback: ((obj: Plug, arg1: string, arg2: boolean) => void))
     connect(sigName: "visible-data-changed", callback: ((obj: Plug) => void))
     /* Signals of GObject.Object */
@@ -1597,9 +1597,9 @@ export interface Registry {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1608,10 +1608,10 @@ export interface Registry {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1654,9 +1654,9 @@ export interface Relation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1665,10 +1665,10 @@ export interface Relation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1715,9 +1715,9 @@ export interface RelationSet {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1726,10 +1726,10 @@ export interface RelationSet {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1796,7 +1796,7 @@ export interface Socket {
     get_object_locale(): string
     get_parent(): Object
     get_role(): Role
-    initialize(data: object): void
+    initialize(data: object | null): void
     notify_state_change(state: State, value: boolean): void
     peek_parent(): Object
     ref_accessible_child(i: number): Object
@@ -1813,9 +1813,9 @@ export interface Socket {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1824,18 +1824,18 @@ export interface Socket {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Atk.Socket */
     vfunc_embed(plug_id: string): void
     /* Virtual methods of Atk.Object */
-    vfunc_active_descendant_changed(child: object): void
-    vfunc_children_changed(change_index: number, changed_child: object): void
+    vfunc_active_descendant_changed(child: object | null): void
+    vfunc_children_changed(change_index: number, changed_child: object | null): void
     vfunc_focus_event(focus_in: boolean): void
     vfunc_get_attributes(): AttributeSet
     vfunc_get_description(): string
@@ -1847,7 +1847,7 @@ export interface Socket {
     vfunc_get_object_locale(): string
     vfunc_get_parent(): Object
     vfunc_get_role(): Role
-    vfunc_initialize(data: object): void
+    vfunc_initialize(data: object | null): void
     vfunc_property_change(values: PropertyValues): void
     vfunc_ref_relation_set(): RelationSet
     vfunc_ref_state_set(): StateSet
@@ -1867,10 +1867,10 @@ export interface Socket {
     vfunc_notify(pspec: GObject.ParamSpec): void
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Atk.Object */
-    connect(sigName: "active-descendant-changed", callback: ((obj: Socket, arg1: object) => void))
-    connect(sigName: "children-changed", callback: ((obj: Socket, arg1: number, arg2: object) => void))
+    connect(sigName: "active-descendant-changed", callback: ((obj: Socket, arg1: object | null) => void))
+    connect(sigName: "children-changed", callback: ((obj: Socket, arg1: number, arg2: object | null) => void))
     connect(sigName: "focus-event", callback: ((obj: Socket, arg1: boolean) => void))
-    connect(sigName: "property-change", callback: ((obj: Socket, arg1: object) => void))
+    connect(sigName: "property-change", callback: ((obj: Socket, arg1: object | null) => void))
     connect(sigName: "state-change", callback: ((obj: Socket, arg1: string, arg2: boolean) => void))
     connect(sigName: "visible-data-changed", callback: ((obj: Socket) => void))
     /* Signals of GObject.Object */
@@ -1922,9 +1922,9 @@ export interface StateSet {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1933,10 +1933,10 @@ export interface StateSet {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1971,9 +1971,9 @@ export interface Util {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1982,10 +1982,10 @@ export interface Util {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void

--- a/out/GLib.d.ts
+++ b/out/GLib.d.ts
@@ -18,6 +18,7 @@ export enum ChecksumType {
     SHA1,
     SHA256,
     SHA512,
+    SHA384,
 }
 export enum ConvertError {
     NO_CONVERSION,
@@ -125,6 +126,10 @@ export enum KeyFileError {
     KEY_NOT_FOUND,
     GROUP_NOT_FOUND,
     INVALID_VALUE,
+}
+export enum LogWriterOutput {
+    HANDLED,
+    UNHANDLED,
 }
 export enum MarkupError {
     BAD_UTF8,
@@ -364,6 +369,9 @@ export enum UnicodeBreakType {
     CONDITIONAL_JAPANESE_STARTER,
     HEBREW_LETTER,
     REGIONAL_INDICATOR,
+    EMOJI_BASE,
+    EMOJI_MODIFIER,
+    ZERO_WIDTH_JOINER,
 }
 export enum UnicodeScript {
     INVALID_CODE,
@@ -499,6 +507,12 @@ export enum UnicodeScript {
     MULTANI,
     OLD_HUNGARIAN,
     SIGNWRITING,
+    ADLAM,
+    BHAIKSUKI,
+    MARCHEN,
+    NEWA,
+    OSAGE,
+    TANGUT,
 }
 export enum UnicodeType {
     CONTROL,
@@ -784,12 +798,9 @@ export const KEY_FILE_DESKTOP_KEY_CATEGORIES:string
 export const KEY_FILE_DESKTOP_KEY_COMMENT:string
 export const KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE:string
 export const KEY_FILE_DESKTOP_KEY_EXEC:string
-export const KEY_FILE_DESKTOP_KEY_FULLNAME:string
 export const KEY_FILE_DESKTOP_KEY_GENERIC_NAME:string
-export const KEY_FILE_DESKTOP_KEY_GETTEXT_DOMAIN:string
 export const KEY_FILE_DESKTOP_KEY_HIDDEN:string
 export const KEY_FILE_DESKTOP_KEY_ICON:string
-export const KEY_FILE_DESKTOP_KEY_KEYWORDS:string
 export const KEY_FILE_DESKTOP_KEY_MIME_TYPE:string
 export const KEY_FILE_DESKTOP_KEY_NAME:string
 export const KEY_FILE_DESKTOP_KEY_NOT_SHOW_IN:string
@@ -832,6 +843,7 @@ export const MODULE_SUFFIX:string
 export const OPTION_REMAINING:string
 export const PDP_ENDIAN:number
 export const PI:number
+export const PID_FORMAT:string
 export const PI_2:number
 export const PI_4:number
 export const POLLFD_FORMAT:string
@@ -875,9 +887,9 @@ export function ascii_formatd(buffer: string, buf_len: number, format: string, d
 export function ascii_strcasecmp(s1: string, s2: string): number
 export function ascii_strdown(str: string, len: number): string
 export function ascii_strncasecmp(s1: string, s2: string, n: number): number
-export function ascii_strtod(nptr: string, endptr: string): number
-export function ascii_strtoll(nptr: string, endptr: string, base: number): number
-export function ascii_strtoull(nptr: string, endptr: string, base: number): number
+export function ascii_strtod(nptr: string): [ /* returnType */ number, /* endptr */ string | null ]
+export function ascii_strtoll(nptr: string, base: number): [ /* returnType */ number, /* endptr */ string | null ]
+export function ascii_strtoull(nptr: string, base: number): [ /* returnType */ number, /* endptr */ string | null ]
 export function ascii_strup(str: string, len: number): string
 export function ascii_tolower(c: number): number
 export function ascii_toupper(c: number): number
@@ -886,7 +898,6 @@ export function assert_warning(log_domain: string, file: string, line: number, p
 export function assertion_message(domain: string, file: string, line: number, func: string, message: string): void
 export function assertion_message_cmpstr(domain: string, file: string, line: number, func: string, expr: string, arg1: string, cmp: string, arg2: string): void
 export function assertion_message_error(domain: string, file: string, line: number, func: string, expr: string, error: Error, error_domain: Quark, error_code: number): void
-export function assertion_message_expr(domain: string, file: string, line: number, func: string, expr: string): void
 export function atexit(func: VoidFunc): void
 export function atomic_int_add(atomic: number, val: number): number
 export function atomic_int_and(atomic: number, val: number): number
@@ -900,9 +911,10 @@ export function atomic_int_set(atomic: number, newval: number): void
 export function atomic_int_xor(atomic: number, val: number): number
 export function atomic_pointer_add(atomic: object, val: number): number
 export function atomic_pointer_and(atomic: object, val: number): number
-export function atomic_pointer_compare_and_exchange(atomic: object, oldval: object, newval: object): boolean
+export function atomic_pointer_compare_and_exchange(atomic: object, oldval: object | null, newval: object | null): boolean
+export function atomic_pointer_get(atomic: object): object | null
 export function atomic_pointer_or(atomic: object, val: number): number
-export function atomic_pointer_set(atomic: object, newval: object): void
+export function atomic_pointer_set(atomic: object, newval: object | null): void
 export function atomic_pointer_xor(atomic: object, val: number): number
 export function base64_decode(text: string): [ /* returnType */ Gjs.byteArray.ByteArray, /* out_len */ number ]
 export function base64_decode_inplace(text: Gjs.byteArray.ByteArray): number
@@ -918,8 +930,8 @@ export function bit_storage(number: number): number
 export function bit_trylock(address: number, lock_bit: number): boolean
 export function bit_unlock(address: number, lock_bit: number): void
 export function bookmark_file_error_quark(): Quark
-export function build_filenamev(args: string[]): string
-export function build_pathv(separator: string, args: string[]): string
+export function build_filenamev(args: any): string
+export function build_pathv(separator: string, args: any): string
 export function byte_array_free(array: Gjs.byteArray.ByteArray, free_segment: boolean): number
 export function byte_array_free_to_bytes(array: Gjs.byteArray.ByteArray): Bytes
 export function byte_array_new(): Gjs.byteArray.ByteArray
@@ -928,28 +940,34 @@ export function byte_array_unref(array: Gjs.byteArray.ByteArray): void
 export function chdir(path: string): number
 export function check_version(required_major: number, required_minor: number, required_micro: number): string
 export function checksum_type_get_length(checksum_type: ChecksumType): number
-export function child_watch_add_full(priority: number, pid: Pid, function_: ChildWatchFunc, data: object, notify: DestroyNotify | null): number
+export function child_watch_add_full(priority: number, pid: Pid, function_: ChildWatchFunc, data: object | null, notify: DestroyNotify | null): number
 export function child_watch_source_new(pid: Pid): Source
 export function clear_error(): void
 export function close(fd: number): boolean
 export function compute_checksum_for_bytes(checksum_type: ChecksumType, data: Bytes): string
 export function compute_checksum_for_data(checksum_type: ChecksumType, data: Gjs.byteArray.ByteArray): string
 export function compute_checksum_for_string(checksum_type: ChecksumType, str: string, length: number): string
-export function compute_hmac_for_data(digest_type: ChecksumType, key: Gjs.byteArray.ByteArray, data: number, length: number): string
+export function compute_hmac_for_bytes(digest_type: ChecksumType, key: Bytes, data: Bytes): string
+export function compute_hmac_for_data(digest_type: ChecksumType, key: Gjs.byteArray.ByteArray, data: Gjs.byteArray.ByteArray): string
 export function compute_hmac_for_string(digest_type: ChecksumType, key: Gjs.byteArray.ByteArray, str: string, length: number): string
 export function convert(str: string, len: number, to_codeset: string, from_codeset: string): [ /* returnType */ string, /* bytes_read */ number, /* bytes_written */ number ]
 export function convert_error_quark(): Quark
 export function convert_with_fallback(str: string, len: number, to_codeset: string, from_codeset: string, fallback: string, bytes_read: number, bytes_written: number): string
 export function convert_with_iconv(str: string, len: number, converter: IConv, bytes_read: number, bytes_written: number): string
 export function datalist_clear(datalist: Data): void
+export function datalist_get_data(datalist: Data, key: string): object | null
 export function datalist_get_flags(datalist: Data): number
+export function datalist_id_get_data(datalist: Data, key_id: Quark): object | null
+export function datalist_id_remove_no_notify(datalist: Data, key_id: Quark): object | null
 export function datalist_id_replace_data(datalist: Data, key_id: Quark, oldval: object | null, newval: object | null, destroy: DestroyNotify | null, old_destroy: DestroyNotify | null): boolean
 export function datalist_id_set_data_full(datalist: Data, key_id: Quark, data: object | null, destroy_func: DestroyNotify): void
 export function datalist_init(datalist: Data): void
 export function datalist_set_flags(datalist: Data, flags: number): void
 export function datalist_unset_flags(datalist: Data, flags: number): void
 export function dataset_destroy(dataset_location: object): void
-export function dataset_id_set_data_full(dataset_location: object, key_id: Quark, data: object, destroy_func: DestroyNotify): void
+export function dataset_id_get_data(dataset_location: object, key_id: Quark): object | null
+export function dataset_id_remove_no_notify(dataset_location: object, key_id: Quark): object | null
+export function dataset_id_set_data_full(dataset_location: object, key_id: Quark, data: object | null, destroy_func: DestroyNotify): void
 export function date_get_days_in_month(month: DateMonth, year: DateYear): number
 export function date_get_monday_weeks_in_year(year: DateYear): number
 export function date_get_sunday_weeks_in_year(year: DateYear): number
@@ -989,7 +1007,7 @@ export function filename_display_name(filename: string): string
 export function filename_from_uri(uri: string): [ /* returnType */ string, /* hostname */ string | null ]
 export function filename_from_utf8(utf8string: string, len: number): [ /* returnType */ Gjs.byteArray.ByteArray, /* bytes_read */ number | null, /* bytes_written */ number ]
 export function filename_to_uri(filename: string, hostname: string | null): string
-export function filename_to_utf8(opsysstring: string, len: number, bytes_read: number, bytes_written: number): string
+export function filename_to_utf8(opsysstring: string, len: number): [ /* returnType */ string, /* bytes_read */ number | null, /* bytes_written */ number | null ]
 export function find_program_in_path(program: string): string
 export function format_size(size: number): string
 export function format_size_for_display(size: number): string
@@ -1011,8 +1029,8 @@ export function get_num_processors(): number
 export function get_prgname(): string
 export function get_real_name(): string
 export function get_real_time(): number
-export function get_system_config_dirs(): string[]
-export function get_system_data_dirs(): string[]
+export function get_system_config_dirs(): any
+export function get_system_data_dirs(): any
 export function get_tmp_dir(): string
 export function get_user_cache_dir(): string
 export function get_user_config_dir(): string
@@ -1021,22 +1039,23 @@ export function get_user_name(): string
 export function get_user_runtime_dir(): string
 export function get_user_special_dir(directory: UserDirectory): string
 export function getenv(variable: string): string
-export function hash_table_add(hash_table: HashTable, key: object): boolean
-export function hash_table_contains(hash_table: HashTable, key: object): boolean
+export function hash_table_add(hash_table: HashTable, key: object | null): boolean
+export function hash_table_contains(hash_table: HashTable, key: object | null): boolean
 export function hash_table_destroy(hash_table: HashTable): void
-export function hash_table_insert(hash_table: HashTable, key: object, value: object): boolean
-export function hash_table_lookup_extended(hash_table: HashTable, lookup_key: object, orig_key: object | null, value: object | null): boolean
-export function hash_table_remove(hash_table: HashTable, key: object): boolean
+export function hash_table_insert(hash_table: HashTable, key: object | null, value: object | null): boolean
+export function hash_table_lookup(hash_table: HashTable, key: object | null): object | null
+export function hash_table_lookup_extended(hash_table: HashTable, lookup_key: object | null): [ /* returnType */ boolean, /* orig_key */ object | null, /* value */ object | null ]
+export function hash_table_remove(hash_table: HashTable, key: object | null): boolean
 export function hash_table_remove_all(hash_table: HashTable): void
-export function hash_table_replace(hash_table: HashTable, key: object, value: object): boolean
+export function hash_table_replace(hash_table: HashTable, key: object | null, value: object | null): boolean
 export function hash_table_size(hash_table: HashTable): number
-export function hash_table_steal(hash_table: HashTable, key: object): boolean
+export function hash_table_steal(hash_table: HashTable, key: object | null): boolean
 export function hash_table_steal_all(hash_table: HashTable): void
 export function hash_table_unref(hash_table: HashTable): void
 export function hook_destroy(hook_list: HookList, hook_id: number): boolean
 export function hook_destroy_link(hook_list: HookList, hook: Hook): void
 export function hook_free(hook_list: HookList, hook: Hook): void
-export function hook_insert_before(hook_list: HookList, sibling: Hook, hook: Hook): void
+export function hook_insert_before(hook_list: HookList, sibling: Hook | null, hook: Hook): void
 export function hook_prepend(hook_list: HookList, hook: Hook): void
 export function hook_unref(hook_list: HookList, hook: Hook): void
 export function hostname_is_ascii_encoded(hostname: string): boolean
@@ -1045,8 +1064,8 @@ export function hostname_is_non_ascii(hostname: string): boolean
 export function hostname_to_ascii(hostname: string): string
 export function hostname_to_unicode(hostname: string): string
 export function iconv(converter: IConv, inbuf: string, inbytes_left: number, outbuf: string, outbytes_left: number): number
-export function idle_add_full(priority: number, function_: SourceFunc, data: object, notify: DestroyNotify | null): number
-export function idle_remove_by_data(data: object): boolean
+export function idle_add_full(priority: number, function_: SourceFunc, data: object | null, notify: DestroyNotify | null): number
+export function idle_remove_by_data(data: object | null): boolean
 export function idle_source_new(): Source
 export function int64_equal(v1: object, v2: object): boolean
 export function int64_hash(v: object): number
@@ -1054,34 +1073,44 @@ export function int_equal(v1: object, v2: object): boolean
 export function int_hash(v: object): number
 export function intern_static_string(string: string | null): string
 export function intern_string(string: string | null): string
-export function io_add_watch_full(channel: IOChannel, priority: number, condition: IOCondition, func: IOFunc, user_data: object, notify: DestroyNotify): number
+export function io_add_watch_full(channel: IOChannel, priority: number, condition: IOCondition, func: IOFunc, user_data: object | null, notify: DestroyNotify): number
 export function io_channel_error_from_errno(en: number): IOChannelError
 export function io_channel_error_quark(): Quark
 export function io_create_watch(channel: IOChannel, condition: IOCondition): Source
 export function key_file_error_quark(): Quark
 export function listenv(): string[]
-export function locale_from_utf8(utf8string: string, len: number, bytes_read: number, bytes_written: number): string
-export function locale_to_utf8(opsysstring: string, len: number, bytes_read: number, bytes_written: number): string
-export function log_default_handler(log_domain: string, log_level: LogLevelFlags, message: string, unused_data: object): void
+export function locale_from_utf8(utf8string: string, len: number): [ /* returnType */ string, /* bytes_read */ number | null, /* bytes_written */ number | null ]
+export function locale_to_utf8(opsysstring: string, len: number): [ /* returnType */ string, /* bytes_read */ number | null, /* bytes_written */ number | null ]
+export function log_default_handler(log_domain: string | null, log_level: LogLevelFlags, message: string | null, unused_data: object | null): void
 export function log_remove_handler(log_domain: string, handler_id: number): void
 export function log_set_always_fatal(fatal_mask: LogLevelFlags): LogLevelFlags
 export function log_set_fatal_mask(log_domain: string, fatal_mask: LogLevelFlags): LogLevelFlags
-export function log_set_handler_full(log_domain: string | null, log_levels: LogLevelFlags, log_func: LogFunc, user_data: object, destroy: DestroyNotify): number
+export function log_set_handler_full(log_domain: string | null, log_levels: LogLevelFlags, log_func: LogFunc, user_data: object | null, destroy: DestroyNotify): number
+export function log_set_writer_func(func: LogWriterFunc | null, user_data: object | null, user_data_free: DestroyNotify): void
+export function log_structured_array(log_level: LogLevelFlags, fields: LogField[]): void
+export function log_variant(log_domain: string | null, log_level: LogLevelFlags, fields: Variant): void
+export function log_writer_default(log_level: LogLevelFlags, fields: LogField[], user_data: object | null): LogWriterOutput
+export function log_writer_format_fields(log_level: LogLevelFlags, fields: LogField[], use_color: boolean): string
+export function log_writer_is_journald(output_fd: number): boolean
+export function log_writer_journald(log_level: LogLevelFlags, fields: LogField[], user_data: object | null): LogWriterOutput
+export function log_writer_standard_streams(log_level: LogLevelFlags, fields: LogField[], user_data: object | null): LogWriterOutput
+export function log_writer_supports_color(output_fd: number): boolean
 export function main_context_default(): MainContext
 export function main_context_get_thread_default(): MainContext
 export function main_context_ref_thread_default(): MainContext
 export function main_current_source(): Source
 export function main_depth(): number
+export function malloc(n_bytes: number): object | null
+export function malloc0(n_bytes: number): object | null
+export function malloc0_n(n_blocks: number, n_block_bytes: number): object | null
+export function malloc_n(n_blocks: number, n_block_bytes: number): object | null
 export function markup_error_quark(): Quark
 export function markup_escape_text(text: string, length: number): string
 export function mem_is_system_malloc(): boolean
 export function mem_profile(): void
 export function mem_set_vtable(vtable: MemVTable): void
+export function memdup(mem: object | null, byte_size: number): object | null
 export function mkdir_with_parents(pathname: string, mode: number): number
-export function mkdtemp(tmpl: string): string
-export function mkdtemp_full(tmpl: string, mode: number): string
-export function mkstemp(tmpl: string): number
-export function mkstemp_full(tmpl: string, flags: number, mode: number): number
 export function nullify_pointer(nullify_location: object): void
 export function on_error_query(prg_name: string): void
 export function on_error_stack_trace(prg_name: string): void
@@ -1092,7 +1121,7 @@ export function parse_debug_string(string: string | null, keys: DebugKey[]): num
 export function path_get_basename(file_name: string): string
 export function path_get_dirname(file_name: string): string
 export function path_is_absolute(file_name: string): boolean
-export function path_skip_root(file_name: string): string | null
+export function path_skip_root(file_name: string): string
 export function pattern_match(pspec: PatternSpec, string_length: number, string: string, string_reversed: string | null): boolean
 export function pattern_match_simple(pattern: string, string: string): boolean
 export function pattern_match_string(pspec: PatternSpec, string: string): boolean
@@ -1100,7 +1129,7 @@ export function pointer_bit_lock(address: object, lock_bit: number): void
 export function pointer_bit_trylock(address: object, lock_bit: number): boolean
 export function pointer_bit_unlock(address: object, lock_bit: number): void
 export function poll(fds: PollFD, nfds: number, timeout: number): number
-export function propagate_error(dest: Error, src: Error): void
+export function propagate_error(src: Error): /* dest */ Error | null
 export function quark_from_static_string(string: string | null): Quark
 export function quark_from_string(string: string | null): Quark
 export function quark_to_string(quark: Quark): string
@@ -1110,6 +1139,8 @@ export function random_double_range(begin: number, end: number): number
 export function random_int(): number
 export function random_int_range(begin: number, end: number): number
 export function random_set_seed(seed: number): void
+export function realloc(mem: object | null, n_bytes: number): object | null
+export function realloc_n(mem: object | null, n_blocks: number, n_block_bytes: number): object | null
 export function regex_check_replacement(replacement: string): [ /* returnType */ boolean, /* has_references */ boolean | null ]
 export function regex_error_quark(): Quark
 export function regex_escape_nul(string: string, length: number): string
@@ -1117,41 +1148,44 @@ export function regex_escape_string(string: string[]): string
 export function regex_match_simple(pattern: string, string: string, compile_options: RegexCompileFlags, match_options: RegexMatchFlags): boolean
 export function regex_split_simple(pattern: string, string: string, compile_options: RegexCompileFlags, match_options: RegexMatchFlags): string[]
 export function reload_user_special_dirs_cache(): void
-export function return_if_fail_warning(log_domain: string, pretty_function: string, expression: string): void
 export function rmdir(filename: string): number
+export function sequence_get(iter: SequenceIter): object | null
 export function sequence_move(src: SequenceIter, dest: SequenceIter): void
 export function sequence_move_range(dest: SequenceIter, begin: SequenceIter, end: SequenceIter): void
 export function sequence_remove(iter: SequenceIter): void
 export function sequence_remove_range(begin: SequenceIter, end: SequenceIter): void
-export function sequence_set(iter: SequenceIter, data: object): void
+export function sequence_set(iter: SequenceIter, data: object | null): void
 export function sequence_swap(a: SequenceIter, b: SequenceIter): void
 export function set_application_name(application_name: string): void
-export function set_error_literal(err: Error | null, domain: Quark, code: number, message: string): void
+export function set_error_literal(domain: Quark, code: number, message: string): /* err */ Error | null
 export function set_prgname(prgname: string): void
 export function setenv(variable: string, value: string, overwrite: boolean): boolean
 export function shell_error_quark(): Quark
 export function shell_parse_argv(command_line: string): [ /* returnType */ boolean, /* argvp */ string[] | null ]
 export function shell_quote(unquoted_string: string): string
 export function shell_unquote(quoted_string: string): string
-export function slice_free1(block_size: number, mem_block: object): void
-export function slice_free_chain_with_offset(block_size: number, mem_chain: object, next_offset: number): void
+export function slice_alloc(block_size: number): object | null
+export function slice_alloc0(block_size: number): object | null
+export function slice_copy(block_size: number, mem_block: object | null): object | null
+export function slice_free1(block_size: number, mem_block: object | null): void
+export function slice_free_chain_with_offset(block_size: number, mem_chain: object | null, next_offset: number): void
 export function slice_get_config(ckey: SliceConfig): number
 export function slice_get_config_state(ckey: SliceConfig, address: number, n_values: number): number
 export function slice_set_config(ckey: SliceConfig, value: number): void
 export function source_remove(tag: number): boolean
-export function source_remove_by_funcs_user_data(funcs: SourceFuncs, user_data: object): boolean
-export function source_remove_by_user_data(user_data: object): boolean
+export function source_remove_by_funcs_user_data(funcs: SourceFuncs, user_data: object | null): boolean
+export function source_remove_by_user_data(user_data: object | null): boolean
 export function source_set_name_by_id(tag: number, name: string): void
 export function spaced_primes_closest(num: number): number
-export function spawn_async(working_directory: string | null, argv: string[], envp: string[] | null, flags: SpawnFlags, child_setup: SpawnChildSetupFunc | null, user_data: object): [ /* returnType */ boolean, /* child_pid */ Pid | null ]
-export function spawn_async_with_pipes(working_directory: string | null, argv: string[], envp: string[] | null, flags: SpawnFlags, child_setup: SpawnChildSetupFunc | null, user_data: object): [ /* returnType */ boolean, /* child_pid */ Pid | null, /* standard_input */ number | null, /* standard_output */ number | null, /* standard_error */ number | null ]
+export function spawn_async(working_directory: string, argv: string[], envp: string[] | null, flags: SpawnFlags, child_setup: SpawnChildSetupFunc | null, user_data: object | null): [ /* returnType */ boolean, /* child_pid */ Pid | null ]
+export function spawn_async_with_pipes(working_directory: string, argv: string[], envp: string[] | null, flags: SpawnFlags, child_setup: SpawnChildSetupFunc | null, user_data: object | null): [ /* returnType */ boolean, /* child_pid */ Pid | null, /* standard_input */ number | null, /* standard_output */ number | null, /* standard_error */ number | null ]
 export function spawn_check_exit_status(exit_status: number): boolean
 export function spawn_close_pid(pid: Pid): void
 export function spawn_command_line_async(command_line: string): boolean
 export function spawn_command_line_sync(command_line: string): [ /* returnType */ boolean, /* standard_output */ Gjs.byteArray.ByteArray | null, /* standard_error */ Gjs.byteArray.ByteArray | null, /* exit_status */ number | null ]
 export function spawn_error_quark(): Quark
 export function spawn_exit_error_quark(): Quark
-export function spawn_sync(working_directory: string | null, argv: string[], envp: string[] | null, flags: SpawnFlags, child_setup: SpawnChildSetupFunc | null, user_data: object): [ /* returnType */ boolean, /* standard_output */ Gjs.byteArray.ByteArray | null, /* standard_error */ Gjs.byteArray.ByteArray | null, /* exit_status */ number | null ]
+export function spawn_sync(working_directory: string, argv: string[], envp: string[] | null, flags: SpawnFlags, child_setup: SpawnChildSetupFunc | null, user_data: object | null): [ /* returnType */ boolean, /* standard_output */ Gjs.byteArray.ByteArray | null, /* standard_error */ Gjs.byteArray.ByteArray | null, /* exit_status */ number | null ]
 export function stpcpy(dest: string, src: string): string
 export function str_equal(v1: object, v2: object): boolean
 export function str_has_prefix(str: string, prefix: string): boolean
@@ -1169,10 +1203,10 @@ export function strcmp0(str1: string | null, str2: string | null): number
 export function strcompress(source: string): string
 export function strdelimit(string: string, delimiters: string | null, new_delimiter: number): string
 export function strdown(string: string): string
-export function strdup(str: string): string
+export function strdup(str: string | null): string
 export function strerror(errnum: number): string
-export function strescape(source: string, exceptions: string): string
-export function strfreev(str_array: string): void
+export function strescape(source: string, exceptions: string | null): string
+export function strfreev(str_array: string | null): void
 export function string_new(init: string | null): String
 export function string_new_len(init: string, len: number): String
 export function string_sized_new(dfl_size: number): String
@@ -1188,13 +1222,13 @@ export function strrstr(haystack: string, needle: string): string
 export function strrstr_len(haystack: string, haystack_len: number, needle: string): string
 export function strsignal(signum: number): string
 export function strstr_len(haystack: string, haystack_len: number, needle: string): string
-export function strtod(nptr: string, endptr: string): number
+export function strtod(nptr: string): [ /* returnType */ number, /* endptr */ string | null ]
 export function strup(string: string): string
 export function strv_contains(strv: string, str: string): boolean
 export function strv_get_type(): number
 export function strv_length(str_array: string): number
-export function test_add_data_func(testpath: string, test_data: object, test_func: TestDataFunc): void
-export function test_add_data_func_full(testpath: string, test_data: object, test_func: TestDataFunc, data_free_func: DestroyNotify): void
+export function test_add_data_func(testpath: string, test_data: object | null, test_func: TestDataFunc): void
+export function test_add_data_func_full(testpath: string, test_data: object | null, test_func: TestDataFunc, data_free_func: DestroyNotify): void
 export function test_add_func(testpath: string, test_func: TestFunc): void
 export function test_assert_expected_messages_internal(domain: string, file: string, line: number, func: string): void
 export function test_bug(bug_uri_snippet: string): void
@@ -1205,8 +1239,8 @@ export function test_failed(): boolean
 export function test_get_dir(file_type: TestFileType): string
 export function test_incomplete(msg: string | null): void
 export function test_log_type_name(log_type: TestLogType): string
-export function test_queue_destroy(destroy_func: DestroyNotify, destroy_data: object): void
-export function test_queue_free(gfree_pointer: object): void
+export function test_queue_destroy(destroy_func: DestroyNotify, destroy_data: object | null): void
+export function test_queue_free(gfree_pointer: object | null): void
 export function test_rand_double(): number
 export function test_rand_double_range(range_start: number, range_end: number): number
 export function test_rand_int(): number
@@ -1225,7 +1259,7 @@ export function test_trap_has_passed(): boolean
 export function test_trap_reached_timeout(): boolean
 export function test_trap_subprocess(test_path: string | null, usec_timeout: number, test_flags: TestSubprocessFlags): void
 export function thread_error_quark(): Quark
-export function thread_exit(retval: object): void
+export function thread_exit(retval: object | null): void
 export function thread_pool_get_max_idle_time(): number
 export function thread_pool_get_max_unused_threads(): number
 export function thread_pool_get_num_unused_threads(): number
@@ -1235,14 +1269,22 @@ export function thread_pool_stop_unused_threads(): void
 export function thread_self(): Thread
 export function thread_yield(): void
 export function time_val_from_iso8601(iso_date: string): [ /* returnType */ boolean, /* time_ */ TimeVal ]
-export function timeout_add_full(priority: number, interval: number, function_: SourceFunc, data: object, notify: DestroyNotify | null): number
-export function timeout_add_seconds_full(priority: number, interval: number, function_: SourceFunc, data: object, notify: DestroyNotify | null): number
+export function timeout_add_full(priority: number, interval: number, function_: SourceFunc, data: object | null, notify: DestroyNotify | null): number
+export function timeout_add_seconds_full(priority: number, interval: number, function_: SourceFunc, data: object | null, notify: DestroyNotify | null): number
 export function timeout_source_new(interval: number): Source
 export function timeout_source_new_seconds(interval: number): Source
 export function trash_stack_height(stack_p: TrashStack): number
+export function trash_stack_peek(stack_p: TrashStack): object | null
+export function trash_stack_pop(stack_p: TrashStack): object | null
 export function trash_stack_push(stack_p: TrashStack, data_p: object): void
-export function ucs4_to_utf16(str: number, len: number, items_read: number | null, items_written: number | null): number
-export function ucs4_to_utf8(str: number, len: number, items_read: number | null, items_written: number | null): string
+export function try_malloc(n_bytes: number): object | null
+export function try_malloc0(n_bytes: number): object | null
+export function try_malloc0_n(n_blocks: number, n_block_bytes: number): object | null
+export function try_malloc_n(n_blocks: number, n_block_bytes: number): object | null
+export function try_realloc(mem: object | null, n_bytes: number): object | null
+export function try_realloc_n(mem: object | null, n_blocks: number, n_block_bytes: number): object | null
+export function ucs4_to_utf16(str: number, len: number): [ /* returnType */ number, /* items_read */ number | null, /* items_written */ number | null ]
+export function ucs4_to_utf8(str: number, len: number): [ /* returnType */ string, /* items_read */ number | null, /* items_written */ number | null ]
 export function unichar_break_type(c: number): UnicodeBreakType
 export function unichar_combining_class(uc: number): number
 export function unichar_compose(a: number, b: number, ch: number): boolean
@@ -1268,7 +1310,7 @@ export function unichar_iswide(c: number): boolean
 export function unichar_iswide_cjk(c: number): boolean
 export function unichar_isxdigit(c: number): boolean
 export function unichar_iszerowidth(c: number): boolean
-export function unichar_to_utf8(c: number, outbuf: string): number
+export function unichar_to_utf8(c: number): [ /* returnType */ number, /* outbuf */ string | null ]
 export function unichar_tolower(c: number): number
 export function unichar_totitle(c: number): number
 export function unichar_toupper(c: number): number
@@ -1280,11 +1322,11 @@ export function unicode_canonical_ordering(string: number, len: number): void
 export function unicode_script_from_iso15924(iso15924: number): UnicodeScript
 export function unicode_script_to_iso15924(script: UnicodeScript): number
 export function unix_error_quark(): Quark
-export function unix_fd_add_full(priority: number, fd: number, condition: IOCondition, function_: UnixFDSourceFunc, user_data: object, notify: DestroyNotify): number
+export function unix_fd_add_full(priority: number, fd: number, condition: IOCondition, function_: UnixFDSourceFunc, user_data: object | null, notify: DestroyNotify): number
 export function unix_fd_source_new(fd: number, condition: IOCondition): Source
 export function unix_open_pipe(fds: number, flags: number): boolean
 export function unix_set_fd_nonblocking(fd: number, nonblock: boolean): boolean
-export function unix_signal_add_full(priority: number, signum: number, handler: SourceFunc, user_data: object, notify: DestroyNotify): number
+export function unix_signal_add_full(priority: number, signum: number, handler: SourceFunc, user_data: object | null, notify: DestroyNotify): number
 export function unix_signal_source_new(signum: number): Source
 export function unlink(filename: string): number
 export function unsetenv(variable: string): void
@@ -1294,16 +1336,17 @@ export function uri_parse_scheme(uri: string): string
 export function uri_unescape_segment(escaped_string: string | null, escaped_string_end: string | null, illegal_characters: string | null): string
 export function uri_unescape_string(escaped_string: string, illegal_characters: string | null): string
 export function usleep(microseconds: number): void
-export function utf16_to_ucs4(str: number, len: number, items_read: number | null, items_written: number | null): number
-export function utf16_to_utf8(str: number, len: number, items_read: number | null, items_written: number | null): string
+export function utf16_to_ucs4(str: number, len: number): [ /* returnType */ number, /* items_read */ number | null, /* items_written */ number | null ]
+export function utf16_to_utf8(str: number, len: number): [ /* returnType */ string, /* items_read */ number | null, /* items_written */ number | null ]
 export function utf8_casefold(str: string, len: number): string
 export function utf8_collate(str1: string, str2: string): number
 export function utf8_collate_key(str: string, len: number): string
 export function utf8_collate_key_for_filename(str: string, len: number): string
-export function utf8_find_next_char(p: string, end: string): string
+export function utf8_find_next_char(p: string, end: string | null): string
 export function utf8_find_prev_char(str: string, p: string): string
 export function utf8_get_char(p: string): number
 export function utf8_get_char_validated(p: string, max_len: number): number
+export function utf8_make_valid(str: string, len: number): string
 export function utf8_normalize(str: string, len: number, mode: NormalizeMode): string
 export function utf8_offset_to_pointer(str: string, offset: number): string
 export function utf8_pointer_to_offset(str: string, pos: string): number
@@ -1316,10 +1359,12 @@ export function utf8_strrchr(p: string, len: number, c: number): string
 export function utf8_strreverse(str: string, len: number): string
 export function utf8_strup(str: string, len: number): string
 export function utf8_substring(str: string, start_pos: number, end_pos: number): string
-export function utf8_to_ucs4(str: string, len: number, items_read: number | null, items_written: number | null): number
-export function utf8_to_ucs4_fast(str: string, len: number, items_written: number | null): number
-export function utf8_to_utf16(str: string, len: number, items_read: number | null, items_written: number | null): number
+export function utf8_to_ucs4(str: string, len: number): [ /* returnType */ number, /* items_read */ number | null, /* items_written */ number | null ]
+export function utf8_to_ucs4_fast(str: string, len: number): [ /* returnType */ number, /* items_written */ number | null ]
+export function utf8_to_utf16(str: string, len: number): [ /* returnType */ number, /* items_read */ number | null, /* items_written */ number | null ]
 export function utf8_validate(str: Gjs.byteArray.ByteArray): [ /* returnType */ boolean, /* end */ string | null ]
+export function uuid_string_is_valid(str: string): boolean
+export function uuid_string_random(): string
 export function variant_get_gtype(): number
 export function variant_is_object_path(string: string): boolean
 export function variant_is_signature(string: string): boolean
@@ -1330,45 +1375,50 @@ export function variant_parser_get_error_quark(): Quark
 export function variant_type_checked_(arg0: string): VariantType
 export function variant_type_string_is_valid(type_string: string): boolean
 export function variant_type_string_scan(string: string, limit: string | null): [ /* returnType */ boolean, /* endptr */ string | null ]
-export function warn_message(domain: string, file: string, line: number, func: string, warnexpr: string): void
 export interface ChildWatchFunc {
-    (pid: Pid, status: number, user_data: object): void
+    (pid: Pid, status: number, user_data: object | null): void
 }
 export interface CompareDataFunc {
-    (a: object, b: object, user_data: object): number
+    (a: object | null, b: object | null, user_data: object | null): number
 }
 export interface CompareFunc {
-    (a: object, b: object): number
+    (a: object | null, b: object | null): number
+}
+export interface CopyFunc {
+    (src: object, data: object | null): object
 }
 export interface DataForeachFunc {
-    (key_id: Quark, data: object, user_data: object): void
+    (key_id: Quark, data: object | null, user_data: object | null): void
 }
 export interface DestroyNotify {
-    (data: object): void
+    (data: object | null): void
+}
+export interface DuplicateFunc {
+    (data: object | null, user_data: object | null): object | null
 }
 export interface EqualFunc {
-    (a: object, b: object): boolean
+    (a: object | null, b: object | null): boolean
 }
 export interface FreeFunc {
-    (data: object): void
+    (data: object | null): void
 }
 export interface Func {
-    (data: object, user_data: object): void
+    (data: object | null, user_data: object | null): void
 }
 export interface HFunc {
-    (key: object, value: object, user_data: object): void
+    (key: object | null, value: object | null, user_data: object | null): void
 }
 export interface HRFunc {
-    (key: object, value: object, user_data: object): boolean
+    (key: object | null, value: object | null, user_data: object | null): boolean
 }
 export interface HashFunc {
-    (key: object): number
+    (key: object | null): number
 }
 export interface HookCheckFunc {
-    (data: object): boolean
+    (data: object | null): boolean
 }
 export interface HookCheckMarshaller {
-    (hook: Hook, marshal_data: object): boolean
+    (hook: Hook, marshal_data: object | null): boolean
 }
 export interface HookCompareFunc {
     (new_hook: Hook, sibling: Hook): number
@@ -1377,34 +1427,37 @@ export interface HookFinalizeFunc {
     (hook_list: HookList, hook: Hook): void
 }
 export interface HookFindFunc {
-    (hook: Hook, data: object): boolean
+    (hook: Hook, data: object | null): boolean
 }
 export interface HookFunc {
-    (data: object): void
+    (data: object | null): void
 }
 export interface HookMarshaller {
-    (hook: Hook, marshal_data: object): void
+    (hook: Hook, marshal_data: object | null): void
 }
 export interface IOFunc {
-    (source: IOChannel, condition: IOCondition, data: object): boolean
+    (source: IOChannel, condition: IOCondition, data: object | null): boolean
 }
 export interface LogFunc {
-    (log_domain: string, log_level: LogLevelFlags, message: string, user_data: object): void
+    (log_domain: string, log_level: LogLevelFlags, message: string, user_data: object | null): void
+}
+export interface LogWriterFunc {
+    (log_level: LogLevelFlags, fields: LogField[], user_data: object | null): LogWriterOutput
 }
 export interface NodeForeachFunc {
-    (node: Node, data: object): void
+    (node: Node, data: object | null): void
 }
 export interface NodeTraverseFunc {
-    (node: Node, data: object): boolean
+    (node: Node, data: object | null): boolean
 }
 export interface OptionArgFunc {
-    (option_name: string, value: string, data: object): boolean
+    (option_name: string, value: string, data: object | null): boolean
 }
 export interface OptionErrorFunc {
-    (context: OptionContext, group: OptionGroup, data: object): void
+    (context: OptionContext, group: OptionGroup, data: object | null): void
 }
 export interface OptionParseFunc {
-    (context: OptionContext, group: OptionGroup, data: object): boolean
+    (context: OptionContext, group: OptionGroup, data: object | null): boolean
 }
 export interface PollFunc {
     (ufds: PollFD, nfsd: number, timeout_: number): number
@@ -1413,43 +1466,46 @@ export interface PrintFunc {
     (string: string): void
 }
 export interface RegexEvalCallback {
-    (match_info: MatchInfo, result: String, user_data: object): boolean
+    (match_info: MatchInfo, result: String, user_data: object | null): boolean
 }
 export interface ScannerMsgFunc {
     (scanner: Scanner, message: string, error: boolean): void
 }
 export interface SequenceIterCompareFunc {
-    (a: SequenceIter, b: SequenceIter, data: object): number
+    (a: SequenceIter, b: SequenceIter, data: object | null): number
 }
 export interface SourceDummyMarshal {
     (): void
 }
 export interface SourceFunc {
-    (user_data: object): boolean
+    (user_data: object | null): boolean
 }
 export interface SpawnChildSetupFunc {
-    (user_data: object): void
+    (user_data: object | null): void
 }
 export interface TestDataFunc {
-    (user_data: object): void
+    (user_data: object | null): void
 }
 export interface TestFixtureFunc {
-    (fixture: object, user_data: object): void
+    (fixture: object, user_data: object | null): void
 }
 export interface TestFunc {
     (): void
 }
 export interface TestLogFatalFunc {
-    (log_domain: string, log_level: LogLevelFlags, message: string, user_data: object): boolean
+    (log_domain: string, log_level: LogLevelFlags, message: string, user_data: object | null): boolean
+}
+export interface ThreadFunc {
+    (data: object | null): object | null
 }
 export interface TranslateFunc {
-    (str: string, data: object): string
+    (str: string, data: object | null): string
 }
 export interface TraverseFunc {
-    (key: object, value: object, data: object): boolean
+    (key: object | null, value: object | null, data: object | null): boolean
 }
 export interface UnixFDSourceFunc {
-    (fd: number, condition: IOCondition, user_data: object): boolean
+    (fd: number, condition: IOCondition, user_data: object | null): boolean
 }
 export interface VoidFunc {
     (): void
@@ -1468,13 +1524,21 @@ export interface AsyncQueue {
     length(): number
     length_unlocked(): number
     lock(): void
-    push(data: object): void
-    push_front(item: object): void
-    push_front_unlocked(item: object): void
-    push_unlocked(data: object): void
+    pop(): object | null
+    pop_unlocked(): object | null
+    push(data: object | null): void
+    push_front(item: object | null): void
+    push_front_unlocked(item: object | null): void
+    push_unlocked(data: object | null): void
     ref_unlocked(): void
-    remove(item: object): boolean
-    remove_unlocked(item: object): boolean
+    remove(item: object | null): boolean
+    remove_unlocked(item: object | null): boolean
+    timed_pop(end_time: TimeVal): object | null
+    timed_pop_unlocked(end_time: TimeVal): object | null
+    timeout_pop(timeout: number): object | null
+    timeout_pop_unlocked(timeout: number): object | null
+    try_pop(): object | null
+    try_pop_unlocked(): object | null
     unlock(): void
     unref(): void
     unref_and_unlock(): void
@@ -1505,7 +1569,7 @@ export interface BookmarkFile {
     has_group(uri: string, group: string): boolean
     has_item(uri: string): boolean
     load_from_data(data: string, length: number): boolean
-    load_from_data_dirs(file: string, full_path: string | null): boolean
+    load_from_data_dirs(file: string, full_path: any): boolean
     load_from_file(filename: string): boolean
     move_item(old_uri: string, new_uri: string | null): boolean
     remove_application(uri: string, name: string): boolean
@@ -1551,14 +1615,14 @@ export interface Bytes {
     /* Methods of GLib.Bytes */
     compare(bytes2: Bytes): number
     equal(bytes2: Bytes): boolean
-    get_data(): [ /* returnType */ Gjs.byteArray.ByteArray, /* size */ number | null ]
+    get_data(): [ /* returnType */ Gjs.byteArray.ByteArray | null, /* size */ number | null ]
     get_size(): number
     hash(): number
     new_from_bytes(offset: number, length: number): Bytes
     ref(): Bytes
     unref(): void
     unref_to_array(): Gjs.byteArray.ByteArray
-    unref_to_data(size: number): object
+    unref_to_data(): [ /* returnType */ Gjs.byteArray.ByteArray, /* size */ number ]
 }
 export interface Bytes_Static {
     name: string
@@ -1773,16 +1837,17 @@ export interface HashTable_Static {
     name: string
 }
 export declare class HashTable_Static {
-    add(hash_table: HashTable, key: object): boolean
-    contains(hash_table: HashTable, key: object): boolean
+    add(hash_table: HashTable, key: object | null): boolean
+    contains(hash_table: HashTable, key: object | null): boolean
     destroy(hash_table: HashTable): void
-    insert(hash_table: HashTable, key: object, value: object): boolean
-    lookup_extended(hash_table: HashTable, lookup_key: object, orig_key: object | null, value: object | null): boolean
-    remove(hash_table: HashTable, key: object): boolean
+    insert(hash_table: HashTable, key: object | null, value: object | null): boolean
+    lookup(hash_table: HashTable, key: object | null): object | null
+    lookup_extended(hash_table: HashTable, lookup_key: object | null): [ /* returnType */ boolean, /* orig_key */ object | null, /* value */ object | null ]
+    remove(hash_table: HashTable, key: object | null): boolean
     remove_all(hash_table: HashTable): void
-    replace(hash_table: HashTable, key: object, value: object): boolean
+    replace(hash_table: HashTable, key: object | null, value: object | null): boolean
     size(hash_table: HashTable): number
-    steal(hash_table: HashTable, key: object): boolean
+    steal(hash_table: HashTable, key: object | null): boolean
     steal_all(hash_table: HashTable): void
     unref(hash_table: HashTable): void
 }
@@ -1791,9 +1856,9 @@ export interface HashTableIter {
     /* Fields of GLib.HashTableIter */
     /* Methods of GLib.HashTableIter */
     init(hash_table: HashTable): void
-    next(key: object | null, value: object | null): boolean
+    next(): [ /* returnType */ boolean, /* key */ object | null, /* value */ object | null ]
     remove(): void
-    replace(value: object): void
+    replace(value: object | null): void
     steal(): void
 }
 export interface HashTableIter_Static {
@@ -1831,7 +1896,7 @@ export declare class Hook_Static {
     destroy(hook_list: HookList, hook_id: number): boolean
     destroy_link(hook_list: HookList, hook: Hook): void
     free(hook_list: HookList, hook: Hook): void
-    insert_before(hook_list: HookList, sibling: Hook, hook: Hook): void
+    insert_before(hook_list: HookList, sibling: Hook | null, hook: Hook): void
     prepend(hook_list: HookList, hook: Hook): void
     unref(hook_list: HookList, hook: Hook): void
 }
@@ -1943,6 +2008,7 @@ export interface KeyFile {
     get_uint64(group_name: string, key: string): number
     get_value(group_name: string, key: string): string
     has_group(group_name: string): boolean
+    load_from_bytes(bytes: Bytes, flags: KeyFileFlags): boolean
     load_from_data(data: string, length: number, flags: KeyFileFlags): boolean
     load_from_data_dirs(file: string, flags: KeyFileFlags): [ /* returnType */ boolean, /* full_path */ any ]
     load_from_dirs(file: string, search_dirs: any, flags: KeyFileFlags): [ /* returnType */ boolean, /* full_path */ any ]
@@ -1988,16 +2054,26 @@ export interface List_Static {
     name: string
 }
 export declare var List: List_Static
+export interface LogField {
+    /* Fields of GLib.LogField */
+    key:string
+    value:object
+    length:number
+}
+export interface LogField_Static {
+    name: string
+}
+export declare var LogField: LogField_Static
 export interface MainContext {
     /* Methods of GLib.MainContext */
     acquire(): boolean
     add_poll(fd: PollFD, priority: number): void
-    check(max_priority: number, fds: PollFD[]): number
+    check(max_priority: number, fds: PollFD[]): boolean
     dispatch(): void
-    find_source_by_funcs_user_data(funcs: SourceFuncs, user_data: object): Source
+    find_source_by_funcs_user_data(funcs: SourceFuncs, user_data: object | null): Source
     find_source_by_id(source_id: number): Source
-    find_source_by_user_data(user_data: object): Source
-    invoke_full(priority: number, function_: SourceFunc, data: object, notify: DestroyNotify | null): void
+    find_source_by_user_data(user_data: object | null): Source
+    invoke_full(priority: number, function_: SourceFunc, data: object | null, notify: DestroyNotify | null): void
     is_owner(): boolean
     iteration(may_block: boolean): boolean
     pending(): boolean
@@ -2064,17 +2140,19 @@ export interface MarkupParseContext {
     free(): void
     get_element(): string
     get_position(line_number: number | null, char_number: number | null): void
+    get_user_data(): object | null
     parse(text: string, text_len: number): boolean
-    push(parser: MarkupParser, user_data: object): void
+    pop(): object | null
+    push(parser: MarkupParser, user_data: object | null): void
     ref(): MarkupParseContext
     unref(): void
 }
 export interface MarkupParseContext_Static {
     name: string
-    new(parser: MarkupParser, flags: MarkupParseFlags, user_data: object, user_data_dnotify: DestroyNotify): MarkupParseContext
+    new(parser: MarkupParser, flags: MarkupParseFlags, user_data: object | null, user_data_dnotify: DestroyNotify): MarkupParseContext
 }
 export declare class MarkupParseContext_Static {
-    new(parser: MarkupParser, flags: MarkupParseFlags, user_data: object, user_data_dnotify: DestroyNotify): MarkupParseContext
+    new(parser: MarkupParser, flags: MarkupParseFlags, user_data: object | null, user_data_dnotify: DestroyNotify): MarkupParseContext
 }
 export declare var MarkupParseContext: MarkupParseContext_Static
 export interface MarkupParser {
@@ -2091,10 +2169,10 @@ export interface MarkupParser_Static {
 export declare var MarkupParser: MarkupParser_Static
 export interface MatchInfo {
     /* Methods of GLib.MatchInfo */
-    expand_references(string_to_expand: string): string
-    fetch(match_num: number): string
+    expand_references(string_to_expand: string): string | null
+    fetch(match_num: number): string | null
     fetch_all(): string[]
-    fetch_named(name: string): string
+    fetch_named(name: string): string | null
     fetch_named_pos(name: string): [ /* returnType */ boolean, /* start_pos */ number | null, /* end_pos */ number | null ]
     fetch_pos(match_num: number): [ /* returnType */ boolean, /* start_pos */ number | null, /* end_pos */ number | null ]
     free(): void
@@ -2113,7 +2191,12 @@ export interface MatchInfo_Static {
 export declare var MatchInfo: MatchInfo_Static
 export interface MemVTable {
     /* Fields of GLib.MemVTable */
+    malloc:any
+    realloc:any
     free:any
+    calloc:any
+    try_malloc:any
+    try_realloc:any
 }
 export interface MemVTable_Static {
     name: string
@@ -2127,7 +2210,7 @@ export interface Node {
     parent:Node
     children:Node
     /* Methods of GLib.Node */
-    child_index(data: object): number
+    child_index(data: object | null): number
     child_position(child: Node): number
     depth(): number
     destroy(): void
@@ -2168,7 +2251,7 @@ export interface OptionContext {
     get_main_group(): OptionGroup
     get_strict_posix(): boolean
     get_summary(): string
-    parse(argv: string[] | null): boolean
+    parse(argv: string[]): boolean
     parse_strv(arguments_: string[]): boolean
     set_description(description: string | null): void
     set_help_enabled(help_enabled: boolean): void
@@ -2236,8 +2319,9 @@ export declare var PollFD: PollFD_Static
 export interface Private {
     /* Fields of GLib.Private */
     /* Methods of GLib.Private */
-    replace(value: object): void
-    set(value: object): void
+    get(): object | null
+    replace(value: object | null): void
+    set(value: object | null): void
 }
 export interface Private_Static {
     name: string
@@ -2262,14 +2346,20 @@ export interface Queue {
     free(): void
     free_full(free_func: DestroyNotify): void
     get_length(): number
-    index(data: object): number
+    index(data: object | null): number
     init(): void
     is_empty(): boolean
-    push_head(data: object): void
-    push_nth(data: object, n: number): void
-    push_tail(data: object): void
-    remove(data: object): boolean
-    remove_all(data: object): number
+    peek_head(): object | null
+    peek_nth(n: number): object | null
+    peek_tail(): object | null
+    pop_head(): object | null
+    pop_nth(n: number): object | null
+    pop_tail(): object | null
+    push_head(data: object | null): void
+    push_nth(data: object | null, n: number): void
+    push_tail(data: object | null): void
+    remove(data: object | null): boolean
+    remove_all(data: object | null): number
     reverse(): void
 }
 export interface Queue_Static {
@@ -2342,10 +2432,10 @@ export interface Regex {
 }
 export interface Regex_Static {
     name: string
-    new(pattern: string, compile_options: RegexCompileFlags, match_options: RegexMatchFlags): Regex
+    new(pattern: string, compile_options: RegexCompileFlags, match_options: RegexMatchFlags): Regex | null
 }
 export declare class Regex_Static {
-    new(pattern: string, compile_options: RegexCompileFlags, match_options: RegexMatchFlags): Regex
+    new(pattern: string, compile_options: RegexCompileFlags, match_options: RegexMatchFlags): Regex | null
     check_replacement(replacement: string): [ /* returnType */ boolean, /* has_references */ boolean | null ]
     error_quark(): Quark
     escape_nul(string: string, length: number): string
@@ -2389,8 +2479,10 @@ export interface Scanner {
     get_next_token(): TokenType
     input_file(input_fd: number): void
     input_text(text: string, text_len: number): void
+    lookup_symbol(symbol: string): object | null
     peek_next_token(): TokenType
-    scope_add_symbol(scope_id: number, symbol: string, value: object): void
+    scope_add_symbol(scope_id: number, symbol: string, value: object | null): void
+    scope_lookup_symbol(scope_id: number, symbol: string): object | null
     scope_remove_symbol(scope_id: number, symbol: string): void
     set_scope(scope_id: number): number
     sync_file_offset(): void
@@ -2443,11 +2535,12 @@ export interface Sequence_Static {
     name: string
 }
 export declare class Sequence_Static {
+    get(iter: SequenceIter): object | null
     move(src: SequenceIter, dest: SequenceIter): void
     move_range(dest: SequenceIter, begin: SequenceIter, end: SequenceIter): void
     remove(iter: SequenceIter): void
     remove_range(begin: SequenceIter, end: SequenceIter): void
-    set(iter: SequenceIter, data: object): void
+    set(iter: SequenceIter, data: object | null): void
     swap(a: SequenceIter, b: SequenceIter): void
 }
 export declare var Sequence: Sequence_Static
@@ -2467,10 +2560,11 @@ export interface Source {
     /* Methods of GLib.Source */
     add_child_source(child_source: Source): void
     add_poll(fd: PollFD): void
+    add_unix_fd(fd: number, events: IOCondition): object
     attach(context: MainContext | null): number
     destroy(): void
     get_can_recurse(): boolean
-    get_context(): MainContext
+    get_context(): MainContext | null
     get_current_time(timeval: TimeVal): void
     get_id(): number
     get_name(): string
@@ -2484,8 +2578,8 @@ export interface Source {
     remove_child_source(child_source: Source): void
     remove_poll(fd: PollFD): void
     remove_unix_fd(tag: object): void
-    set_callback(func: SourceFunc, data: object, notify: DestroyNotify | null): void
-    set_callback_indirect(callback_data: object, callback_funcs: SourceCallbackFuncs): void
+    set_callback(func: SourceFunc, data: object | null, notify: DestroyNotify | null): void
+    set_callback_indirect(callback_data: object | null, callback_funcs: SourceCallbackFuncs): void
     set_can_recurse(can_recurse: boolean): void
     set_funcs(funcs: SourceFuncs): void
     set_name(name: string): void
@@ -2500,8 +2594,8 @@ export interface Source_Static {
 export declare class Source_Static {
     new(source_funcs: SourceFuncs, struct_size: number): Source
     remove(tag: number): boolean
-    remove_by_funcs_user_data(funcs: SourceFuncs, user_data: object): boolean
-    remove_by_user_data(user_data: object): boolean
+    remove_by_funcs_user_data(funcs: SourceFuncs, user_data: object | null): boolean
+    remove_by_user_data(user_data: object | null): boolean
     set_name_by_id(tag: number, name: string): void
 }
 export declare var Source: Source_Static
@@ -2640,6 +2734,7 @@ export interface TestSuite_Static {
 export declare var TestSuite: TestSuite_Static
 export interface Thread {
     /* Methods of GLib.Thread */
+    join(): object | null
     ref(): Thread
     unref(): void
 }
@@ -2648,7 +2743,7 @@ export interface Thread_Static {
 }
 export declare class Thread_Static {
     error_quark(): Quark
-    exit(retval: object): void
+    exit(retval: object | null): void
     self(): Thread
     yield(): void
 }
@@ -2662,8 +2757,8 @@ export interface ThreadPool {
     free(immediate: boolean, wait_: boolean): void
     get_max_threads(): number
     get_num_threads(): number
-    move_to_front(data: object): boolean
-    push(data: object): boolean
+    move_to_front(data: object | null): boolean
+    push(data: object | null): boolean
     set_max_threads(max_threads: number): boolean
     unprocessed(): number
 }
@@ -2736,6 +2831,8 @@ export interface TrashStack_Static {
 }
 export declare class TrashStack_Static {
     height(stack_p: TrashStack): number
+    peek(stack_p: TrashStack): object | null
+    pop(stack_p: TrashStack): object | null
     push(stack_p: TrashStack, data_p: object): void
 }
 export declare var TrashStack: TrashStack_Static
@@ -2743,12 +2840,13 @@ export interface Tree {
     /* Methods of GLib.Tree */
     destroy(): void
     height(): number
-    insert(key: object, value: object): void
-    lookup_extended(lookup_key: object, orig_key: object, value: object): boolean
+    insert(key: object | null, value: object | null): void
+    lookup(key: object | null): object | null
+    lookup_extended(lookup_key: object | null, orig_key: object | null, value: object | null): boolean
     nnodes(): number
-    remove(key: object): boolean
-    replace(key: object, value: object): void
-    steal(key: object): boolean
+    remove(key: object | null): boolean
+    replace(key: object | null, value: object | null): void
+    steal(key: object | null): boolean
     unref(): void
 }
 export interface Tree_Static {
@@ -2772,14 +2870,14 @@ export interface Variant {
     get_bytestring(): Gjs.byteArray.ByteArray
     get_bytestring_array(): [ /* returnType */ string[], /* length */ number | null ]
     get_child_value(index_: number): Variant
-    get_data(): object
+    get_data(): object | null
     get_data_as_bytes(): Bytes
     get_double(): number
     get_handle(): number
     get_int16(): number
     get_int32(): number
     get_int64(): number
-    get_maybe(): Variant
+    get_maybe(): Variant | null
     get_normal_form(): Variant
     get_objv(): [ /* returnType */ string[], /* length */ number | null ]
     get_size(): number
@@ -2816,9 +2914,9 @@ export declare class Variant_Static {
     new_bytestring_array(strv: string[], length: number): Variant
     new_dict_entry(key: Variant, value: Variant): Variant
     new_double(value: number): Variant
-    new_fixed_array(element_type: VariantType, elements: object, n_elements: number, element_size: number): Variant
+    new_fixed_array(element_type: VariantType, elements: object | null, n_elements: number, element_size: number): Variant
     new_from_bytes(type: VariantType, bytes: Bytes, trusted: boolean): Variant
-    new_from_data(type: VariantType, data: Gjs.byteArray.ByteArray, size: number, trusted: boolean, notify: DestroyNotify, user_data: object): Variant
+    new_from_data(type: VariantType, data: Gjs.byteArray.ByteArray, size: number, trusted: boolean, notify: DestroyNotify, user_data: object | null): Variant
     new_handle(value: number): Variant
     new_int16(value: number): Variant
     new_int32(value: number): Variant
@@ -2843,7 +2941,6 @@ export declare class Variant_Static {
 }
 export declare var Variant: Variant_Static
 export interface VariantBuilder {
-    /* Fields of GLib.VariantBuilder */
     /* Methods of GLib.VariantBuilder */
     add_value(value: Variant): void
     close(): void
@@ -2861,7 +2958,6 @@ export declare class VariantBuilder_Static {
 }
 export declare var VariantBuilder: VariantBuilder_Static
 export interface VariantDict {
-    /* Fields of GLib.VariantDict */
     /* Methods of GLib.VariantDict */
     clear(): void
     contains(key: string): boolean
@@ -2885,7 +2981,7 @@ export interface VariantIter {
     /* Methods of GLib.VariantIter */
     free(): void
     n_children(): number
-    next_value(): Variant
+    next_value(): Variant | null
 }
 export interface VariantIter_Static {
     name: string
@@ -2978,55 +3074,12 @@ export interface TokenValue_Static {
     name: string
 }
 export declare var TokenValue: TokenValue_Static
-type Array_autoptr = object
-type AsyncQueue_autoptr = object
-type BookmarkFile_autoptr = object
-type ByteArray_autoptr = object
-type Bytes_autoptr = object
-type Checksum_autoptr = object
 type DateDay = number
-type DateTime_autoptr = object
 type DateYear = number
-type Dir_autoptr = object
-type Error_autoptr = object
-type HashTable_autoptr = object
-type Hmac_autoptr = object
-type IOChannel_autoptr = object
-type KeyFile_autoptr = object
-type List_autoptr = object
-type MainContext_autoptr = object
-type MainLoop_autoptr = object
-type MappedFile_autoptr = object
-type MarkupParseContext_autoptr = object
-type MatchInfo_autoptr = object
-type MutexLocker = object
-type MutexLocker_autoptr = object
-type Node_autoptr = object
-type OptionContext_autoptr = object
-type OptionGroup_autoptr = object
-type PatternSpec_autoptr = object
+type MutexLocker = void
 type Pid = number
-type PtrArray_autoptr = object
 type Quark = number
-type Queue_autoptr = object
-type Rand_autoptr = object
-type Regex_autoptr = object
-type SList_autoptr = object
-type Scanner_autoptr = object
-type Sequence_autoptr = object
-type Source_autoptr = object
-type StringChunk_autoptr = object
-type String_autoptr = object
-type Strv = object
-type Thread_autoptr = object
+type Strv = string
 type Time = number
 type TimeSpan = number
-type TimeZone_autoptr = object
-type Timer_autoptr = object
-type Tree_autoptr = object
 type Type = number
-type VariantBuilder_autoptr = object
-type VariantDict_autoptr = object
-type VariantIter_autoptr = object
-type VariantType_autoptr = object
-type Variant_autoptr = object

--- a/out/GModule.d.ts
+++ b/out/GModule.d.ts
@@ -23,7 +23,7 @@ export interface Module {
     close(): boolean
     make_resident(): void
     name(): string
-    symbol(symbol_name: string): [ /* returnType */ boolean, /* symbol */ object ]
+    symbol(symbol_name: string): [ /* returnType */ boolean, /* symbol */ object | null ]
 }
 export interface Module_Static {
     name: string

--- a/out/GObject.d.ts
+++ b/out/GObject.d.ts
@@ -81,29 +81,29 @@ export const VALUE_COLLECT_FORMAT_MAX_LENGTH:number
 export const VALUE_NOCOPY_CONTENTS:number
 export function boxed_copy(boxed_type: number, src_boxed: object): object
 export function boxed_free(boxed_type: number, boxed: object): void
-export function cclosure_marshal_BOOLEAN__BOXED_BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_BOOLEAN__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_STRING__OBJECT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__BOOLEAN(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__CHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__DOUBLE(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__ENUM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__FLOAT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__INT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__LONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__OBJECT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__PARAM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__STRING(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__UCHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__UINT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__UINT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__ULONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__VARIANT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_VOID__VOID(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-export function cclosure_marshal_generic(closure: Closure, return_gvalue: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
+export function cclosure_marshal_BOOLEAN__BOXED_BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_BOOLEAN__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_STRING__OBJECT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__BOOLEAN(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__CHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__DOUBLE(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__ENUM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__FLOAT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__INT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__LONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__OBJECT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__PARAM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__STRING(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__UCHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__UINT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__UINT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__ULONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__VARIANT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_VOID__VOID(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+export function cclosure_marshal_generic(closure: Closure, return_gvalue: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
 export function enum_complete_type_info(g_enum_type: number, const_values: EnumValue): /* info */ TypeInfo
 export function enum_get_value(enum_class: EnumClass, value: number): EnumValue
 export function enum_get_value_by_name(enum_class: EnumClass, name: string): EnumValue
@@ -130,7 +130,7 @@ export function param_spec_object(name: string, nick: string, blurb: string, obj
 export function param_spec_param(name: string, nick: string, blurb: string, param_type: number, flags: ParamFlags): ParamSpec
 export function param_spec_pointer(name: string, nick: string, blurb: string, flags: ParamFlags): ParamSpec
 export function param_spec_pool_new(type_prefixing: boolean): ParamSpecPool
-export function param_spec_string(name: string, nick: string, blurb: string, default_value: string, flags: ParamFlags): ParamSpec
+export function param_spec_string(name: string, nick: string, blurb: string, default_value: string | null, flags: ParamFlags): ParamSpec
 export function param_spec_uchar(name: string, nick: string, blurb: string, minimum: number, maximum: number, default_value: number, flags: ParamFlags): ParamSpec
 export function param_spec_uint(name: string, nick: string, blurb: string, minimum: number, maximum: number, default_value: number, flags: ParamFlags): ParamSpec
 export function param_spec_uint64(name: string, nick: string, blurb: string, minimum: number, maximum: number, default_value: number, flags: ParamFlags): ParamSpec
@@ -144,9 +144,9 @@ export function param_value_set_default(pspec: ParamSpec, value: Value): void
 export function param_value_validate(pspec: ParamSpec, value: Value): boolean
 export function param_values_cmp(pspec: ParamSpec, value1: Value, value2: Value): number
 export function pointer_type_register_static(name: string): number
-export function signal_accumulator_first_wins(ihint: SignalInvocationHint, return_accu: Value, handler_return: Value, dummy: object): boolean
-export function signal_accumulator_true_handled(ihint: SignalInvocationHint, return_accu: Value, handler_return: Value, dummy: object): boolean
-export function signal_add_emission_hook(signal_id: number, detail: GLib.Quark, hook_func: SignalEmissionHook, hook_data: object, data_destroy: GLib.DestroyNotify): number
+export function signal_accumulator_first_wins(ihint: SignalInvocationHint, return_accu: Value, handler_return: Value, dummy: object | null): boolean
+export function signal_accumulator_true_handled(ihint: SignalInvocationHint, return_accu: Value, handler_return: Value, dummy: object | null): boolean
+export function signal_add_emission_hook(signal_id: number, detail: GLib.Quark, hook_func: SignalEmissionHook, hook_data: object | null, data_destroy: GLib.DestroyNotify): number
 export function signal_chain_from_overridden(instance_and_params: Value[], return_value: Value): void
 export function signal_connect_closure(instance: Object, detailed_signal: string, closure: Closure, after: boolean): number
 export function signal_connect_closure_by_id(instance: Object, signal_id: number, detail: GLib.Quark, closure: Closure, after: boolean): number
@@ -154,13 +154,13 @@ export function signal_emitv(instance_and_params: Value[], signal_id: number, de
 export function signal_get_invocation_hint(instance: Object): SignalInvocationHint
 export function signal_handler_block(instance: Object, handler_id: number): void
 export function signal_handler_disconnect(instance: Object, handler_id: number): void
-export function signal_handler_find(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object, data: object): number
+export function signal_handler_find(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object | null, data: object | null): number
 export function signal_handler_is_connected(instance: Object, handler_id: number): boolean
 export function signal_handler_unblock(instance: Object, handler_id: number): void
-export function signal_handlers_block_matched(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object, data: object): number
+export function signal_handlers_block_matched(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object | null, data: object | null): number
 export function signal_handlers_destroy(instance: Object): void
-export function signal_handlers_disconnect_matched(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object, data: object): number
-export function signal_handlers_unblock_matched(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object, data: object): number
+export function signal_handlers_disconnect_matched(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object | null, data: object | null): number
+export function signal_handlers_unblock_matched(instance: Object, mask: SignalMatchType, signal_id: number, detail: GLib.Quark, closure: Closure | null, func: object | null, data: object | null): number
 export function signal_has_handler_pending(instance: Object, signal_id: number, detail: GLib.Quark, may_be_blocked: boolean): boolean
 export function signal_list_ids(itype: number): [ /* returnType */ number[], /* n_ids */ number ]
 export function signal_lookup(name: string, itype: number): number
@@ -188,8 +188,7 @@ export function type_check_is_value_type(type: number): boolean
 export function type_check_value(value: Value): boolean
 export function type_check_value_holds(value: Value, type: number): boolean
 export function type_children(type: number): [ /* returnType */ number, /* n_children */ number | null ]
-export function type_class_add_private(g_class: object, private_size: number): void
-export function type_class_adjust_private_offset(g_class: object, private_size_or_offset: number): void
+export function type_class_adjust_private_offset(g_class: object | null, private_size_or_offset: number): void
 export function type_class_peek(type: number): TypeClass
 export function type_class_peek_static(type: number): TypeClass
 export function type_class_ref(type: number): TypeClass
@@ -204,7 +203,7 @@ export function type_fundamental(type_id: number): number
 export function type_fundamental_next(): number
 export function type_get_instance_count(type: number): number
 export function type_get_plugin(type: number): TypePlugin
-export function type_get_qdata(type: number, quark: GLib.Quark): object
+export function type_get_qdata(type: number, quark: GLib.Quark): object | null
 export function type_get_type_registration_serial(): number
 export function type_init(): void
 export function type_init_with_debug_flags(debug_flags: TypeDebugFlags): void
@@ -224,7 +223,7 @@ export function type_query(type: number): /* query */ TypeQuery
 export function type_register_dynamic(parent_type: number, type_name: string, plugin: TypePlugin, flags: TypeFlags): number
 export function type_register_fundamental(type_id: number, type_name: string, info: TypeInfo, finfo: TypeFundamentalInfo, flags: TypeFlags): number
 export function type_register_static(parent_type: number, type_name: string, info: TypeInfo, flags: TypeFlags): number
-export function type_set_qdata(type: number, quark: GLib.Quark, data: object): void
+export function type_set_qdata(type: number, quark: GLib.Quark, data: object | null): void
 export function type_test_flags(type: number, flags: number): boolean
 export function value_type_compatible(src_type: number, dest_type: number): boolean
 export function value_type_transformable(src_type: number, dest_type: number): boolean
@@ -235,7 +234,10 @@ export interface BaseInitFunc {
     (g_class: TypeClass): void
 }
 export interface BindingTransformFunc {
-    (binding: Binding, from_value: Value, to_value: Value, user_data: object): boolean
+    (binding: Binding, from_value: Value, to_value: Value, user_data: object | null): boolean
+}
+export interface BoxedCopyFunc {
+    (boxed: object): object
 }
 export interface BoxedFreeFunc {
     (boxed: object): void
@@ -244,25 +246,25 @@ export interface Callback {
     (): void
 }
 export interface ClassFinalizeFunc {
-    (g_class: TypeClass, class_data: object): void
+    (g_class: TypeClass, class_data: object | null): void
 }
 export interface ClassInitFunc {
-    (g_class: TypeClass, class_data: object): void
+    (g_class: TypeClass, class_data: object | null): void
 }
 export interface ClosureMarshal {
     (closure: Closure, return_value: Value | null, param_values: Value[], invocation_hint: object | null, marshal_data: object | null): void
 }
 export interface ClosureNotify {
-    (data: object, closure: Closure): void
+    (data: object | null, closure: Closure): void
 }
 export interface InstanceInitFunc {
     (instance: TypeInstance, g_class: TypeClass): void
 }
 export interface InterfaceFinalizeFunc {
-    (g_iface: TypeInterface, iface_data: object): void
+    (g_iface: TypeInterface, iface_data: object | null): void
 }
 export interface InterfaceInitFunc {
-    (g_iface: TypeInterface, iface_data: object): void
+    (g_iface: TypeInterface, iface_data: object | null): void
 }
 export interface ObjectFinalizeFunc {
     (object: Object): void
@@ -274,19 +276,19 @@ export interface ObjectSetPropertyFunc {
     (object: Object, property_id: number, value: Value, pspec: ParamSpec): void
 }
 export interface SignalAccumulator {
-    (ihint: SignalInvocationHint, return_accu: Value, handler_return: Value, data: object): boolean
+    (ihint: SignalInvocationHint, return_accu: Value, handler_return: Value, data: object | null): boolean
 }
 export interface SignalEmissionHook {
-    (ihint: SignalInvocationHint, param_values: Value[], data: object): boolean
+    (ihint: SignalInvocationHint, param_values: Value[], data: object | null): boolean
 }
 export interface ToggleNotify {
-    (data: object, object: Object, is_last_ref: boolean): void
+    (data: object | null, object: Object, is_last_ref: boolean): void
 }
 export interface TypeClassCacheFunc {
-    (cache_data: object, g_class: TypeClass): boolean
+    (cache_data: object | null, g_class: TypeClass): boolean
 }
 export interface TypeInterfaceCheckFunc {
-    (check_data: object, g_iface: TypeInterface): void
+    (check_data: object | null, g_iface: TypeInterface): void
 }
 export interface TypePluginCompleteInterfaceInfo {
     (plugin: TypePlugin, instance_type: number, interface_type: number, info: InterfaceInfo): void
@@ -304,7 +306,7 @@ export interface ValueTransform {
     (src_value: Value, dest_value: Value): void
 }
 export interface WeakNotify {
-    (data: object, where_the_object_was: Object): void
+    (data: object | null, where_the_object_was: Object): void
 }
 export interface TypePlugin {
     /* Methods of GObject.TypePlugin */
@@ -340,9 +342,9 @@ export interface Binding {
     bind_property_with_closures(source_property: string, target: Object, target_property: string, flags: BindingFlags, transform_to: Closure, transform_from: Closure): Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: ParamSpec): void
@@ -351,10 +353,10 @@ export interface Binding {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: Closure): void
@@ -385,9 +387,9 @@ export interface InitiallyUnowned {
     bind_property_with_closures(source_property: string, target: Object, target_property: string, flags: BindingFlags, transform_to: Closure, transform_from: Closure): Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: ParamSpec): void
@@ -396,10 +398,10 @@ export interface InitiallyUnowned {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: Closure): void
@@ -429,9 +431,9 @@ export interface Object {
     bind_property_with_closures(source_property: string, target: Object, target_property: string, flags: BindingFlags, transform_to: Closure, transform_from: Closure): Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: ParamSpec): void
@@ -440,10 +442,10 @@ export interface Object {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: Closure): void
@@ -464,10 +466,10 @@ export interface Object_Static {
 }
 export declare class Object_Static {
     newv(object_type: number, n_parameters: number, parameters: Parameter[]): Object
-    compat_control(what: number, data: object): number
-    interface_find_property(g_iface: object, property_name: string): ParamSpec
-    interface_install_property(g_iface: object, pspec: ParamSpec): void
-    interface_list_properties(g_iface: object): [ /* returnType */ ParamSpec[], /* n_properties_p */ number ]
+    compat_control(what: number, data: object | null): number
+    interface_find_property(g_iface: TypeInterface, property_name: string): ParamSpec
+    interface_install_property(g_iface: TypeInterface, pspec: ParamSpec): void
+    interface_list_properties(g_iface: TypeInterface): [ /* returnType */ ParamSpec[], /* n_properties_p */ number ]
 }
 export declare var Object: Object_Static
 export interface ParamSpec {
@@ -483,11 +485,11 @@ export interface ParamSpec {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -514,11 +516,11 @@ export interface ParamSpecBoolean {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -544,11 +546,11 @@ export interface ParamSpecBoxed {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -577,11 +579,11 @@ export interface ParamSpecChar {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -611,11 +613,11 @@ export interface ParamSpecDouble {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -643,11 +645,11 @@ export interface ParamSpecEnum {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -675,11 +677,11 @@ export interface ParamSpecFlags {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -709,11 +711,11 @@ export interface ParamSpecFloat {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -740,11 +742,11 @@ export interface ParamSpecGType {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -773,11 +775,11 @@ export interface ParamSpecInt {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -806,11 +808,11 @@ export interface ParamSpecInt64 {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -839,11 +841,11 @@ export interface ParamSpecLong {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -869,11 +871,11 @@ export interface ParamSpecObject {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -898,11 +900,11 @@ export interface ParamSpecOverride {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -928,11 +930,11 @@ export interface ParamSpecParam {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -958,11 +960,11 @@ export interface ParamSpecPointer {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -994,11 +996,11 @@ export interface ParamSpecString {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1027,11 +1029,11 @@ export interface ParamSpecUChar {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1060,11 +1062,11 @@ export interface ParamSpecUInt {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1093,11 +1095,11 @@ export interface ParamSpecUInt64 {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1126,11 +1128,11 @@ export interface ParamSpecULong {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1157,11 +1159,11 @@ export interface ParamSpecUnichar {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1189,11 +1191,11 @@ export interface ParamSpecValueArray {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1221,11 +1223,11 @@ export interface ParamSpecVariant {
     get_name(): string
     get_name_quark(): GLib.Quark
     get_nick(): string
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     get_redirect_target(): ParamSpec
-    set_qdata(quark: GLib.Quark, data: object): void
+    set_qdata(quark: GLib.Quark, data: object | null): void
     sink(): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     /* Virtual methods of GObject.ParamSpec */
     vfunc_finalize(): void
     vfunc_value_set_default(value: Value): void
@@ -1260,9 +1262,9 @@ export interface TypeModule {
     bind_property_with_closures(source_property: string, target: Object, target_property: string, flags: BindingFlags, transform_to: Closure, transform_from: Closure): Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: ParamSpec): void
@@ -1271,10 +1273,10 @@ export interface TypeModule {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: Closure): void
@@ -1306,29 +1308,29 @@ export interface CClosure_Static {
     name: string
 }
 export declare class CClosure_Static {
-    marshal_BOOLEAN__BOXED_BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_BOOLEAN__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_STRING__OBJECT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__BOOLEAN(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__CHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__DOUBLE(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__ENUM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__FLOAT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__INT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__LONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__OBJECT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__PARAM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__STRING(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__UCHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__UINT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__UINT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__ULONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__VARIANT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_VOID__VOID(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
-    marshal_generic(closure: Closure, return_gvalue: Value, n_param_values: number, param_values: Value, invocation_hint: object, marshal_data: object): void
+    marshal_BOOLEAN__BOXED_BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_BOOLEAN__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_STRING__OBJECT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__BOOLEAN(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__BOXED(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__CHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__DOUBLE(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__ENUM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__FLAGS(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__FLOAT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__INT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__LONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__OBJECT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__PARAM(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__STRING(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__UCHAR(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__UINT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__UINT_POINTER(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__ULONG(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__VARIANT(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_VOID__VOID(closure: Closure, return_value: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
+    marshal_generic(closure: Closure, return_gvalue: Value, n_param_values: number, param_values: Value, invocation_hint: object | null, marshal_data: object | null): void
 }
 export declare var CClosure: CClosure_Static
 export interface Closure {
@@ -1338,7 +1340,7 @@ export interface Closure {
     marshal:any
     /* Methods of GObject.Closure */
     invalidate(): void
-    invoke(return_value: Value | null, param_values: Value[], invocation_hint: object | null): void
+    invoke(param_values: Value[], invocation_hint: object | null): /* return_value */ Value | null
     ref(): Closure
     sink(): void
     unref(): void
@@ -1348,7 +1350,7 @@ export interface Closure_Static {
 }
 export declare class Closure_Static {
     new_object(sizeof_closure: number, object: Object): Closure
-    new_simple(sizeof_closure: number, data: object): Closure
+    new_simple(sizeof_closure: number, data: object | null): Closure
 }
 export declare var Closure: Closure_Static
 export interface ClosureNotifyData {
@@ -1488,6 +1490,8 @@ export declare var SignalQuery: SignalQuery_Static
 export interface TypeClass {
     /* Fields of GObject.TypeClass */
     /* Methods of GObject.TypeClass */
+    add_private(private_size: number): void
+    get_private(private_type: number): object | null
     peek_parent(): TypeClass
     unref(): void
 }
@@ -1495,8 +1499,7 @@ export interface TypeClass_Static {
     name: string
 }
 export declare class TypeClass_Static {
-    add_private(g_class: object, private_size: number): void
-    adjust_private_offset(g_class: object, private_size_or_offset: number): void
+    adjust_private_offset(g_class: object | null, private_size_or_offset: number): void
     peek(type: number): TypeClass
     peek_static(type: number): TypeClass
     ref(type: number): TypeClass
@@ -1530,6 +1533,7 @@ export declare var TypeInfo: TypeInfo_Static
 export interface TypeInstance {
     /* Fields of GObject.TypeInstance */
     /* Methods of GObject.TypeInstance */
+    get_private(private_type: number): object | null
 }
 export interface TypeInstance_Static {
     name: string
@@ -1577,6 +1581,7 @@ export interface TypeValueTable {
     value_init:any
     value_free:any
     value_copy:any
+    value_peek_pointer:any
     collect_format:string
     collect_value:any
     lcopy_format:string
@@ -1596,7 +1601,7 @@ export interface Value {
     dup_variant(): GLib.Variant
     fits_pointer(): boolean
     get_boolean(): boolean
-    get_boxed(): object
+    get_boxed(): object | null
     get_char(): number
     get_double(): number
     get_enum(): number
@@ -1608,7 +1613,7 @@ export interface Value {
     get_long(): number
     get_object(): Object
     get_param(): ParamSpec
-    get_pointer(): object
+    get_pointer(): object | null
     get_schar(): number
     get_string(): string
     get_uchar(): number
@@ -1617,8 +1622,8 @@ export interface Value {
     get_ulong(): number
     get_variant(): GLib.Variant
     init(g_type: number): Value
-    init_from_instance(instance: object): void
-    peek_pointer(): object
+    init_from_instance(instance: TypeInstance): void
+    peek_pointer(): object | null
     reset(): Value
     set_boolean(v_boolean: boolean): void
     set_boxed(v_boxed: object | null): void
@@ -1635,7 +1640,7 @@ export interface Value {
     set_long(v_long: number): void
     set_object(v_object: Object | null): void
     set_param(param: ParamSpec | null): void
-    set_pointer(v_pointer: object): void
+    set_pointer(v_pointer: object | null): void
     set_schar(v_char: number): void
     set_static_boxed(v_boxed: object | null): void
     set_static_string(v_string: string | null): void
@@ -1672,7 +1677,7 @@ export interface ValueArray {
     insert(index_: number, value: Value | null): ValueArray
     prepend(value: Value | null): ValueArray
     remove(index_: number): ValueArray
-    sort_with_data(compare_func: GLib.CompareDataFunc, user_data: object): ValueArray
+    sort_with_data(compare_func: GLib.CompareDataFunc, user_data: object | null): ValueArray
 }
 export interface ValueArray_Static {
     name: string
@@ -1717,8 +1722,6 @@ export interface _Value__data__union_Static {
     name: string
 }
 export declare var _Value__data__union: _Value__data__union_Static
-type InitiallyUnowned_autoptr = object
-type Object_autoptr = object
 type SignalCMarshaller = ClosureMarshal
 type SignalCVaMarshaller = any
 type Type = number

--- a/out/Gdk.d.ts
+++ b/out/Gdk.d.ts
@@ -18,6 +18,9 @@ export enum AxisUse {
     XTILT,
     YTILT,
     WHEEL,
+    DISTANCE,
+    ROTATION,
+    SLIDER,
     LAST,
 }
 export enum ByteOrder {
@@ -117,10 +120,30 @@ export enum CursorType {
     BLANK_CURSOR,
     CURSOR_IS_PIXMAP,
 }
+export enum DevicePadFeature {
+    BUTTON,
+    RING,
+    STRIP,
+}
+export enum DeviceToolType {
+    UNKNOWN,
+    PEN,
+    ERASER,
+    BRUSH,
+    PENCIL,
+    AIRBRUSH,
+    MOUSE,
+    LENS,
+}
 export enum DeviceType {
     MASTER,
     SLAVE,
     FLOATING,
+}
+export enum DragCancelReason {
+    NO_TARGET,
+    USER_CANCELLED,
+    ERROR,
 }
 export enum DragProtocol {
     NONE,
@@ -178,6 +201,11 @@ export enum EventType {
     TOUCH_CANCEL,
     TOUCHPAD_SWIPE,
     TOUCHPAD_PINCH,
+    PAD_BUTTON_PRESS,
+    PAD_BUTTON_RELEASE,
+    PAD_RING,
+    PAD_STRIP,
+    PAD_GROUP_MODE,
     EVENT_LAST,
 }
 export enum FilterReturn {
@@ -232,6 +260,8 @@ export enum InputSource {
     KEYBOARD,
     TOUCHSCREEN,
     TOUCHPAD,
+    TRACKPOINT,
+    TABLET_PAD,
 }
 export enum ModifierIntent {
     PRIMARY_ACCELERATOR,
@@ -282,6 +312,14 @@ export enum Status {
     ERROR_PARAM,
     ERROR_FILE,
     ERROR_MEM,
+}
+export enum SubpixelLayout {
+    UNKNOWN,
+    NONE,
+    HORIZONTAL_RGB,
+    HORIZONTAL_BGR,
+    VERTICAL_RGB,
+    VERTICAL_BGR,
 }
 export enum TouchpadGesturePhase {
     BEGIN,
@@ -341,6 +379,28 @@ export enum WindowWindowClass {
     INPUT_OUTPUT,
     INPUT_ONLY,
 }
+export enum AnchorHints {
+    FLIP_X,
+    FLIP_Y,
+    SLIDE_X,
+    SLIDE_Y,
+    RESIZE_X,
+    RESIZE_Y,
+    FLIP,
+    SLIDE,
+    RESIZE,
+}
+export enum AxisFlags {
+    X,
+    Y,
+    PRESSURE,
+    XTILT,
+    YTILT,
+    WHEEL,
+    DISTANCE,
+    ROTATION,
+    SLIDER,
+}
 export enum DragAction {
     DEFAULT,
     COPY,
@@ -374,6 +434,7 @@ export enum EventMask {
     TOUCH_MASK,
     SMOOTH_SCROLL_MASK,
     TOUCHPAD_GESTURE_MASK,
+    TABLET_PAD_MASK,
     ALL_EVENTS_MASK,
 }
 export enum FrameClockPhase {
@@ -419,6 +480,15 @@ export enum ModifierType {
     MODIFIER_RESERVED_29_MASK,
     RELEASE_MASK,
     MODIFIER_MASK,
+}
+export enum SeatCapabilities {
+    NONE,
+    POINTER,
+    TOUCH,
+    TABLET_STYLUS,
+    KEYBOARD,
+    ALL_POINTING,
+    ALL,
 }
 export enum WMDecoration {
     ALL,
@@ -2755,6 +2825,7 @@ export function beep(): void
 export function cairo_create(window: Window): cairo.Context
 export function cairo_draw_from_gl(cr: cairo.Context, window: Window, source: number, source_type: number, buffer_scale: number, x: number, y: number, width: number, height: number): void
 export function cairo_get_clip_rectangle(cr: cairo.Context): [ /* returnType */ boolean, /* rect */ Rectangle | null ]
+export function cairo_get_drawing_context(cr: cairo.Context): DrawingContext | null
 export function cairo_rectangle(cr: cairo.Context, rectangle: Rectangle): void
 export function cairo_region(cr: cairo.Context, region: cairo.Region): void
 export function cairo_region_create_from_surface(surface: cairo.Surface): cairo.Region
@@ -2768,7 +2839,9 @@ export function disable_multidevice(): void
 export function drag_abort(context: DragContext, time_: number): void
 export function drag_begin(window: Window, targets: GLib.List): DragContext
 export function drag_begin_for_device(window: Window, device: Device, targets: GLib.List): DragContext
+export function drag_begin_from_point(window: Window, device: Device, targets: GLib.List, x_root: number, y_root: number): DragContext
 export function drag_drop(context: DragContext, time_: number): void
+export function drag_drop_done(context: DragContext, success: boolean): void
 export function drag_drop_succeeded(context: DragContext): boolean
 export function drag_find_window_for_screen(context: DragContext, drag_window: Window, screen: Screen, x_root: number, y_root: number): [ /* dest_window */ Window, /* protocol */ DragProtocol ]
 export function drag_get_selection(context: DragContext): Atom
@@ -2780,7 +2853,7 @@ export function error_trap_pop(): number
 export function error_trap_pop_ignored(): void
 export function error_trap_push(): void
 export function event_get(): Event | null
-export function event_handler_set(func: EventFunc, data: object, notify: GLib.DestroyNotify): void
+export function event_handler_set(func: EventFunc, data: object | null, notify: GLib.DestroyNotify): void
 export function event_peek(): Event | null
 export function event_request_motions(event: EventMotion): void
 export function events_get_angle(event1: Event, event2: Event): [ /* returnType */ boolean, /* angle */ number ]
@@ -2813,6 +2886,7 @@ export function offscreen_window_get_embedder(window: Window): Window | null
 export function offscreen_window_get_surface(window: Window): cairo.Surface | null
 export function offscreen_window_set_embedder(window: Window, embedder: Window): void
 export function pango_context_get(): Pango.Context
+export function pango_context_get_for_display(display: Display): Pango.Context
 export function pango_context_get_for_screen(screen: Screen): Pango.Context
 export function parse_args(argv: string[]): void
 export function pixbuf_get_from_surface(surface: cairo.Surface, src_x: number, src_y: number, width: number, height: number): GdkPixbuf.Pixbuf | null
@@ -2842,26 +2916,40 @@ export function test_render_sync(window: Window): void
 export function test_simulate_button(window: Window, x: number, y: number, button: number, modifiers: ModifierType, button_pressrelease: EventType): boolean
 export function test_simulate_key(window: Window, x: number, y: number, keyval: number, modifiers: ModifierType, key_pressrelease: EventType): boolean
 export function text_property_to_utf8_list_for_display(display: Display, encoding: Atom, format: number, text: Gjs.byteArray.ByteArray): [ /* returnType */ number, /* list */ string[] ]
-export function threads_add_idle_full(priority: number, function_: GLib.SourceFunc, data: object, notify: GLib.DestroyNotify | null): number
-export function threads_add_timeout_full(priority: number, interval: number, function_: GLib.SourceFunc, data: object, notify: GLib.DestroyNotify | null): number
-export function threads_add_timeout_seconds_full(priority: number, interval: number, function_: GLib.SourceFunc, data: object, notify: GLib.DestroyNotify | null): number
+export function threads_add_idle_full(priority: number, function_: GLib.SourceFunc, data: object | null, notify: GLib.DestroyNotify | null): number
+export function threads_add_timeout_full(priority: number, interval: number, function_: GLib.SourceFunc, data: object | null, notify: GLib.DestroyNotify | null): number
+export function threads_add_timeout_seconds_full(priority: number, interval: number, function_: GLib.SourceFunc, data: object | null, notify: GLib.DestroyNotify | null): number
 export function threads_enter(): void
 export function threads_init(): void
 export function threads_leave(): void
 export function unicode_to_keyval(wc: number): number
 export function utf8_to_string_target(str: string): string | null
 export interface EventFunc {
-    (event: Event, data: object): void
+    (event: Event, data: object | null): void
 }
 export interface FilterFunc {
-    (xevent: XEvent, event: Event, data: object): FilterReturn
+    (xevent: XEvent, event: Event, data: object | null): FilterReturn
+}
+export interface SeatGrabPrepareFunc {
+    (seat: Seat, window: Window, user_data: object | null): void
 }
 export interface WindowChildFunc {
-    (window: Window, user_data: object): boolean
+    (window: Window, user_data: object | null): boolean
 }
 export interface WindowInvalidateHandlerFunc {
     (window: Window, region: cairo.Region): void
 }
+export interface DevicePad {
+    /* Methods of Gdk.DevicePad */
+    get_feature_group(feature: DevicePadFeature, feature_idx: number): number
+    get_group_n_modes(group_idx: number): number
+    get_n_features(feature: DevicePadFeature): number
+    get_n_groups(): number
+}
+export interface DevicePad_Static {
+    name: string
+}
+export declare var DevicePad: DevicePad_Static
 export interface AppLaunchContext_ConstructProps extends Gio.AppLaunchContext_ConstructProps {
     display?:Display
 }
@@ -2890,9 +2978,9 @@ export interface AppLaunchContext {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2901,10 +2989,10 @@ export interface AppLaunchContext {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2955,9 +3043,9 @@ export interface Cursor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2965,10 +3053,10 @@ export interface Cursor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of GObject.Object */
@@ -3001,25 +3089,31 @@ export interface Device_ConstructProps extends GObject.Object_ConstructProps {
     input_mode?:InputMode
     input_source?:InputSource
     name?:string
+    num_touches?:number
     product_id?:string
+    seat?:Seat
     type?:DeviceType
     vendor_id?:string
 }
 export interface Device {
     /* Properties of Gdk.Device */
     readonly associated_device:Device
+    readonly axes:AxisFlags
     input_mode:InputMode
     readonly n_axes:number
+    seat:Seat
+    readonly tool:DeviceTool
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Gdk.Device */
     get_associated_device(): Device | null
+    get_axes(): AxisFlags
     get_axis_use(index_: number): AxisUse
     get_device_type(): DeviceType
     get_display(): Display
     get_has_cursor(): boolean
     get_key(index_: number): [ /* returnType */ boolean, /* keyval */ number, /* modifiers */ ModifierType ]
-    get_last_event_window(): Window
+    get_last_event_window(): Window | null
     get_mode(): InputMode
     get_n_axes(): number
     get_n_keys(): number
@@ -3027,6 +3121,7 @@ export interface Device {
     get_position(): [ /* screen */ Screen | null, /* x */ number | null, /* y */ number | null ]
     get_position_double(): [ /* screen */ Screen | null, /* x */ number | null, /* y */ number | null ]
     get_product_id(): string | null
+    get_seat(): Seat
     get_source(): InputSource
     get_vendor_id(): string | null
     get_window_at_position(): [ /* returnType */ Window | null, /* win_x */ number | null, /* win_y */ number | null ]
@@ -3044,9 +3139,9 @@ export interface Device {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3055,10 +3150,10 @@ export interface Device {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3072,11 +3167,15 @@ export interface Device {
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Gdk.Device */
     connect(sigName: "changed", callback: ((obj: Device) => void))
+    connect(sigName: "tool-changed", callback: ((obj: Device, tool: DeviceTool) => void))
     /* Signals of GObject.Object */
     connect(sigName: "notify", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::associated-device", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::axes", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::input-mode", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::n-axes", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::seat", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::tool", callback: ((obj: Device, pspec: GObject.ParamSpec) => void))
 }
 export interface Device_Static {
     name: string
@@ -3102,9 +3201,9 @@ export interface DeviceManager {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3113,10 +3212,10 @@ export interface DeviceManager {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3140,6 +3239,59 @@ export interface DeviceManager_Static {
     new (config?: DeviceManager_ConstructProps): DeviceManager
 }
 export declare var DeviceManager: DeviceManager_Static
+export interface DeviceTool_ConstructProps extends GObject.Object_ConstructProps {
+    axes?:AxisFlags
+    hardware_id?:number
+    serial?:number
+    tool_type?:DeviceToolType
+}
+export interface DeviceTool {
+    /* Properties of Gdk.DeviceTool */
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Gdk.DeviceTool */
+    get_hardware_id(): number
+    get_serial(): number
+    get_tool_type(): DeviceToolType
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: DeviceTool, pspec: GObject.ParamSpec) => void))
+}
+export interface DeviceTool_Static {
+    name: string
+    new (config?: DeviceTool_ConstructProps): DeviceTool
+}
+export declare var DeviceTool: DeviceTool_Static
 export interface Display_ConstructProps extends GObject.Object_ConstructProps {
 }
 export interface Display {
@@ -3154,18 +3306,25 @@ export interface Display {
     get_default_cursor_size(): number
     get_default_group(): Window
     get_default_screen(): Screen
+    get_default_seat(): Seat
     get_device_manager(): DeviceManager | null
     get_event(): Event | null
     get_maximal_cursor_size(): [ /* width */ number, /* height */ number ]
+    get_monitor(monitor_num: number): Monitor | null
+    get_monitor_at_point(x: number, y: number): Monitor
+    get_monitor_at_window(window: Window): Monitor
+    get_n_monitors(): number
     get_n_screens(): number
     get_name(): string
     get_pointer(): [ /* screen */ Screen | null, /* x */ number | null, /* y */ number | null, /* mask */ ModifierType | null ]
+    get_primary_monitor(): Monitor | null
     get_screen(screen_num: number): Screen
     get_window_at_pointer(): [ /* returnType */ Window | null, /* win_x */ number | null, /* win_y */ number | null ]
     has_pending(): boolean
     is_closed(): boolean
     keyboard_ungrab(time_: number): void
     list_devices(): GLib.List
+    list_seats(): GLib.List
     notify_startup_complete(startup_id: string): void
     peek_event(): Event | null
     pointer_is_grabbed(): boolean
@@ -3174,7 +3333,7 @@ export interface Display {
     request_selection_notification(selection: Atom): boolean
     set_double_click_distance(distance: number): void
     set_double_click_time(msec: number): void
-    store_clipboard(clipboard_window: Window, time_: number, targets: Atom[]): void
+    store_clipboard(clipboard_window: Window, time_: number, targets: Atom[] | null): void
     supports_clipboard_persistence(): boolean
     supports_composite(): boolean
     supports_cursor_alpha(): boolean
@@ -3189,9 +3348,9 @@ export interface Display {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3200,10 +3359,10 @@ export interface Display {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3217,7 +3376,11 @@ export interface Display {
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of Gdk.Display */
     connect(sigName: "closed", callback: ((obj: Display, is_error: boolean) => void))
+    connect(sigName: "monitor-added", callback: ((obj: Display, monitor: Monitor) => void))
+    connect(sigName: "monitor-removed", callback: ((obj: Display, monitor: Monitor) => void))
     connect(sigName: "opened", callback: ((obj: Display) => void))
+    connect(sigName: "seat-added", callback: ((obj: Display, seat: Seat) => void))
+    connect(sigName: "seat-removed", callback: ((obj: Display, seat: Seat) => void))
     /* Signals of GObject.Object */
     connect(sigName: "notify", callback: ((obj: Display, pspec: GObject.ParamSpec) => void))
 }
@@ -3249,9 +3412,9 @@ export interface DisplayManager {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3260,10 +3423,10 @@ export interface DisplayManager {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3298,20 +3461,23 @@ export interface DragContext {
     get_actions(): DragAction
     get_dest_window(): Window
     get_device(): Device
+    get_drag_window(): Window | null
     get_protocol(): DragProtocol
     get_selected_action(): DragAction
     get_source_window(): Window
     get_suggested_action(): DragAction
     list_targets(): GLib.List
+    manage_dnd(ipc_window: Window, actions: DragAction): boolean
     set_device(device: Device): void
+    set_hotspot(hot_x: number, hot_y: number): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3320,10 +3486,67 @@ export interface DragContext {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of Gdk.DragContext */
+    connect(sigName: "action-changed", callback: ((obj: DragContext, action: DragAction) => void))
+    connect(sigName: "cancel", callback: ((obj: DragContext, reason: DragCancelReason) => void))
+    connect(sigName: "dnd-finished", callback: ((obj: DragContext) => void))
+    connect(sigName: "drop-performed", callback: ((obj: DragContext, time: number) => void))
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: DragContext, pspec: GObject.ParamSpec) => void))
+}
+export interface DragContext_Static {
+    name: string
+    new (config?: DragContext_ConstructProps): DragContext
+}
+export declare var DragContext: DragContext_Static
+export interface DrawingContext_ConstructProps extends GObject.Object_ConstructProps {
+    clip?:cairo.Region
+    window?:Window
+}
+export interface DrawingContext {
+    /* Properties of Gdk.DrawingContext */
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Gdk.DrawingContext */
+    get_cairo_context(): cairo.Context
+    get_clip(): cairo.Region | null
+    get_window(): Window
+    is_valid(): boolean
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3336,13 +3559,13 @@ export interface DragContext {
     vfunc_notify(pspec: GObject.ParamSpec): void
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of GObject.Object */
-    connect(sigName: "notify", callback: ((obj: DragContext, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify", callback: ((obj: DrawingContext, pspec: GObject.ParamSpec) => void))
 }
-export interface DragContext_Static {
+export interface DrawingContext_Static {
     name: string
-    new (config?: DragContext_ConstructProps): DragContext
+    new (config?: DrawingContext_ConstructProps): DrawingContext
 }
-export declare var DragContext: DragContext_Static
+export declare var DrawingContext: DrawingContext_Static
 export interface FrameClock_ConstructProps extends GObject.Object_ConstructProps {
 }
 export interface FrameClock {
@@ -3363,9 +3586,9 @@ export interface FrameClock {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3374,10 +3597,10 @@ export interface FrameClock {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3416,25 +3639,28 @@ export interface GLContext {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gdk.GLContext */
     get_debug_enabled(): boolean
-    get_display(): Display
+    get_display(): Display | null
     get_forward_compatible(): boolean
     get_required_version(): [ /* major */ number | null, /* minor */ number | null ]
-    get_shared_context(): GLContext
+    get_shared_context(): GLContext | null
+    get_use_es(): boolean
     get_version(): [ /* major */ number, /* minor */ number ]
-    get_window(): Window
+    get_window(): Window | null
+    is_legacy(): boolean
     make_current(): void
     realize(): boolean
     set_debug_enabled(enabled: boolean): void
     set_forward_compatible(compatible: boolean): void
     set_required_version(major: number, minor: number): void
+    set_use_es(use_es: number): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3443,10 +3669,10 @@ export interface GLContext {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3467,7 +3693,7 @@ export interface GLContext_Static {
 }
 export declare class GLContext_Static {
     clear_current(): void
-    get_current(): GLContext
+    get_current(): GLContext | null
 }
 export declare var GLContext: GLContext_Static
 export interface Keymap_ConstructProps extends GObject.Object_ConstructProps {
@@ -3479,7 +3705,7 @@ export interface Keymap {
     add_virtual_modifiers(state: ModifierType): void
     get_caps_lock_state(): boolean
     get_direction(): Pango.Direction
-    get_entries_for_keycode(hardware_keycode: number): [ /* returnType */ boolean, /* keys */ KeymapKey[], /* keyvals */ number[] ]
+    get_entries_for_keycode(hardware_keycode: number): [ /* returnType */ boolean, /* keys */ KeymapKey[] | null, /* keyvals */ number[] | null ]
     get_entries_for_keyval(keyval: number): [ /* returnType */ boolean, /* keys */ KeymapKey[] ]
     get_modifier_mask(intent: ModifierIntent): ModifierType
     get_modifier_state(): number
@@ -3494,9 +3720,9 @@ export interface Keymap {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3505,10 +3731,10 @@ export interface Keymap {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3536,6 +3762,84 @@ export declare class Keymap_Static {
     get_for_display(display: Display): Keymap
 }
 export declare var Keymap: Keymap_Static
+export interface Monitor_ConstructProps extends GObject.Object_ConstructProps {
+    display?:Display
+}
+export interface Monitor {
+    /* Properties of Gdk.Monitor */
+    readonly geometry:Rectangle
+    readonly height_mm:number
+    readonly manufacturer:string
+    readonly model:string
+    readonly refresh_rate:number
+    readonly scale_factor:number
+    readonly subpixel_layout:SubpixelLayout
+    readonly width_mm:number
+    readonly workarea:Rectangle
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Gdk.Monitor */
+    get_display(): Display
+    get_geometry(): /* geometry */ Rectangle
+    get_height_mm(): number
+    get_manufacturer(): string | null
+    get_model(): string | null
+    get_refresh_rate(): number
+    get_scale_factor(): number
+    get_subpixel_layout(): SubpixelLayout
+    get_width_mm(): number
+    get_workarea(): /* workarea */ Rectangle
+    is_primary(): boolean
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of Gdk.Monitor */
+    connect(sigName: "invalidate", callback: ((obj: Monitor) => void))
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::geometry", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::height-mm", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::manufacturer", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::model", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::refresh-rate", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::scale-factor", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::subpixel-layout", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::width-mm", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::workarea", callback: ((obj: Monitor, pspec: GObject.ParamSpec) => void))
+}
+export interface Monitor_Static {
+    name: string
+    new (config?: Monitor_ConstructProps): Monitor
+}
+export declare var Monitor: Monitor_Static
 export interface Screen_ConstructProps extends GObject.Object_ConstructProps {
     font_options?:object
     resolution?:number
@@ -3582,9 +3886,9 @@ export interface Screen {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3593,10 +3897,10 @@ export interface Screen {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3629,6 +3933,67 @@ export declare class Screen_Static {
     width_mm(): number
 }
 export declare var Screen: Screen_Static
+export interface Seat_ConstructProps extends GObject.Object_ConstructProps {
+    display?:Display
+}
+export interface Seat {
+    /* Properties of Gdk.Seat */
+    /* Fields of Gdk.Seat */
+    parent_instance:GObject.Object
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Gdk.Seat */
+    get_capabilities(): SeatCapabilities
+    get_display(): Display
+    get_keyboard(): Device | null
+    get_pointer(): Device | null
+    get_slaves(capabilities: SeatCapabilities): GLib.List
+    grab(window: Window, capabilities: SeatCapabilities, owner_events: boolean, cursor: Cursor | null, event: Event | null, prepare_func: SeatGrabPrepareFunc | null, prepare_func_data: object | null): GrabStatus
+    ungrab(): void
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of Gdk.Seat */
+    connect(sigName: "device-added", callback: ((obj: Seat, device: Device) => void))
+    connect(sigName: "device-removed", callback: ((obj: Seat, device: Device) => void))
+    connect(sigName: "tool-added", callback: ((obj: Seat, tool: DeviceTool) => void))
+    connect(sigName: "tool-removed", callback: ((obj: Seat, tool: DeviceTool) => void))
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: Seat, pspec: GObject.ParamSpec) => void))
+}
+export interface Seat_Static {
+    name: string
+    new (config?: Seat_ConstructProps): Seat
+}
+export declare var Seat: Seat_Static
 export interface Visual_ConstructProps extends GObject.Object_ConstructProps {
 }
 export interface Visual {
@@ -3649,9 +4014,9 @@ export interface Visual {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3660,10 +4025,10 @@ export interface Visual {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3702,6 +4067,7 @@ export interface Window {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gdk.Window */
     beep(): void
+    begin_draw_frame(region: cairo.Region): DrawingContext
     begin_move_drag(button: number, root_x: number, root_y: number, timestamp: number): void
     begin_move_drag_for_device(device: Device, button: number, root_x: number, root_y: number, timestamp: number): void
     begin_paint_rect(rectangle: Rectangle): void
@@ -3718,6 +4084,7 @@ export interface Window {
     destroy(): void
     destroy_notify(): void
     enable_synchronized_configure(): void
+    end_draw_frame(context: DrawingContext): void
     end_paint(): void
     ensure_native(): boolean
     flush(): void
@@ -3730,7 +4097,7 @@ export interface Window {
     get_accept_focus(): boolean
     get_background_pattern(): cairo.Pattern | null
     get_children(): GLib.List
-    get_children_with_user_data(user_data: object): GLib.List
+    get_children_with_user_data(user_data: object | null): GLib.List
     get_clip_region(): cairo.Region
     get_composited(): boolean
     get_cursor(): Cursor | null
@@ -3768,7 +4135,7 @@ export interface Window {
     get_toplevel(): Window
     get_type_hint(): WindowTypeHint
     get_update_area(): cairo.Region
-    get_user_data(): /* data */ object
+    get_user_data(): /* data */ object | null
     get_visible_region(): cairo.Region
     get_visual(): Visual
     get_width(): number
@@ -3777,7 +4144,7 @@ export interface Window {
     hide(): void
     iconify(): void
     input_shape_combine_region(shape_region: cairo.Region, offset_x: number, offset_y: number): void
-    invalidate_maybe_recurse(region: cairo.Region, child_func: WindowChildFunc | null, user_data: object): void
+    invalidate_maybe_recurse(region: cairo.Region, child_func: WindowChildFunc | null, user_data: object | null): void
     invalidate_rect(rect: Rectangle | null, invalidate_children: boolean): void
     invalidate_region(region: cairo.Region, invalidate_children: boolean): void
     is_destroyed(): boolean
@@ -3857,9 +4224,9 @@ export interface Window {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3868,10 +4235,10 @@ export interface Window {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3890,6 +4257,7 @@ export interface Window {
     /* Signals of Gdk.Window */
     connect(sigName: "create-surface", callback: ((obj: Window, width: number, height: number) => cairo.Surface))
     connect(sigName: "from-embedder", callback: ((obj: Window, embedder_x: number, embedder_y: number) => void))
+    connect(sigName: "moved-to-rect", callback: ((obj: Window, flipped_rect: object | null, final_rect: object | null, flipped_x: boolean, flipped_y: boolean) => void))
     connect(sigName: "pick-embedded-child", callback: ((obj: Window, x: number, y: number) => Window | null))
     connect(sigName: "to-embedder", callback: ((obj: Window, offscreen_x: number, offscreen_y: number) => void))
     /* Signals of GObject.Object */
@@ -4106,6 +4474,48 @@ export interface EventOwnerChange_Static {
     name: string
 }
 export declare var EventOwnerChange: EventOwnerChange_Static
+export interface EventPadAxis {
+    /* Fields of Gdk.EventPadAxis */
+    type:EventType
+    window:Window
+    send_event:number
+    time:number
+    group:number
+    index:number
+    mode:number
+    value:number
+}
+export interface EventPadAxis_Static {
+    name: string
+}
+export declare var EventPadAxis: EventPadAxis_Static
+export interface EventPadButton {
+    /* Fields of Gdk.EventPadButton */
+    type:EventType
+    window:Window
+    send_event:number
+    time:number
+    group:number
+    button:number
+    mode:number
+}
+export interface EventPadButton_Static {
+    name: string
+}
+export declare var EventPadButton: EventPadButton_Static
+export interface EventPadGroupMode {
+    /* Fields of Gdk.EventPadGroupMode */
+    type:EventType
+    window:Window
+    send_event:number
+    time:number
+    group:number
+    mode:number
+}
+export interface EventPadGroupMode_Static {
+    name: string
+}
+export declare var EventPadGroupMode: EventPadGroupMode_Static
 export interface EventProperty {
     /* Fields of Gdk.EventProperty */
     type:EventType
@@ -4146,6 +4556,7 @@ export interface EventScroll {
     y_root:number
     delta_x:number
     delta_y:number
+    is_stop:number
 }
 export interface EventScroll_Static {
     name: string
@@ -4352,6 +4763,7 @@ export interface Rectangle {
     width:number
     height:number
     /* Methods of Gdk.Rectangle */
+    equal(rect2: Rectangle): boolean
     intersect(src2: Rectangle): [ /* returnType */ boolean, /* dest */ Rectangle | null ]
     union(src2: Rectangle): /* dest */ Rectangle
 }
@@ -4419,6 +4831,9 @@ export interface Event {
     grab_broken:EventGrabBroken
     touchpad_swipe:EventTouchpadSwipe
     touchpad_pinch:EventTouchpadPinch
+    pad_button:EventPadButton
+    pad_axis:EventPadAxis
+    pad_group_mode:EventPadGroupMode
     /* Methods of Gdk.Event */
     _get_angle(event2: Event): [ /* returnType */ boolean, /* angle */ number ]
     _get_center(event2: Event): [ /* returnType */ boolean, /* x */ number, /* y */ number ]
@@ -4430,20 +4845,26 @@ export interface Event {
     get_click_count(): [ /* returnType */ boolean, /* click_count */ number ]
     get_coords(): [ /* returnType */ boolean, /* x_win */ number | null, /* y_win */ number | null ]
     get_device(): Device | null
+    get_device_tool(): DeviceTool
     get_event_sequence(): EventSequence
     get_event_type(): EventType
     get_keycode(): [ /* returnType */ boolean, /* keycode */ number ]
     get_keyval(): [ /* returnType */ boolean, /* keyval */ number ]
+    get_pointer_emulated(): boolean
     get_root_coords(): [ /* returnType */ boolean, /* x_root */ number | null, /* y_root */ number | null ]
+    get_scancode(): number
     get_screen(): Screen
     get_scroll_deltas(): [ /* returnType */ boolean, /* delta_x */ number, /* delta_y */ number ]
     get_scroll_direction(): [ /* returnType */ boolean, /* direction */ ScrollDirection ]
+    get_seat(): Seat
     get_source_device(): Device | null
     get_state(): [ /* returnType */ boolean, /* state */ ModifierType ]
     get_time(): number
     get_window(): Window
+    is_scroll_stop_event(): boolean
     put(): void
     set_device(device: Device): void
+    set_device_tool(tool: DeviceTool | null): void
     set_screen(screen: Screen): void
     set_source_device(device: Device): void
     triggers_context_menu(): boolean
@@ -4455,9 +4876,9 @@ export interface Event_Static {
 export declare class Event_Static {
     new(type: EventType): Event
     get(): Event | null
-    handler_set(func: EventFunc, data: object, notify: GLib.DestroyNotify): void
+    handler_set(func: EventFunc, data: object | null, notify: GLib.DestroyNotify): void
     peek(): Event | null
     request_motions(event: EventMotion): void
 }
 export declare var Event: Event_Static
-type XEvent = object
+type XEvent = void

--- a/out/Gio.d.ts
+++ b/out/Gio.d.ts
@@ -348,6 +348,7 @@ export enum ApplicationFlags {
     HANDLES_COMMAND_LINE,
     SEND_ENVIRONMENT,
     NON_UNIQUE,
+    CAN_OVERRIDE_APP_ID,
 }
 export enum AskPasswordFlags {
     NEED_PASSWORD,
@@ -556,6 +557,7 @@ export const FILE_ATTRIBUTE_DOS_IS_SYSTEM:string
 export const FILE_ATTRIBUTE_ETAG_VALUE:string
 export const FILE_ATTRIBUTE_FILESYSTEM_FREE:string
 export const FILE_ATTRIBUTE_FILESYSTEM_READONLY:string
+export const FILE_ATTRIBUTE_FILESYSTEM_REMOTE:string
 export const FILE_ATTRIBUTE_FILESYSTEM_SIZE:string
 export const FILE_ATTRIBUTE_FILESYSTEM_TYPE:string
 export const FILE_ATTRIBUTE_FILESYSTEM_USED:string
@@ -579,6 +581,7 @@ export const FILE_ATTRIBUTE_OWNER_GROUP:string
 export const FILE_ATTRIBUTE_OWNER_USER:string
 export const FILE_ATTRIBUTE_OWNER_USER_REAL:string
 export const FILE_ATTRIBUTE_PREVIEW_ICON:string
+export const FILE_ATTRIBUTE_RECENT_MODIFIED:string
 export const FILE_ATTRIBUTE_SELINUX_CONTEXT:string
 export const FILE_ATTRIBUTE_STANDARD_ALLOCATED_SIZE:string
 export const FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE:string
@@ -635,6 +638,7 @@ export const NATIVE_VOLUME_MONITOR_EXTENSION_POINT_NAME:string
 export const NETWORK_MONITOR_EXTENSION_POINT_NAME:string
 export const PROXY_EXTENSION_POINT_NAME:string
 export const PROXY_RESOLVER_EXTENSION_POINT_NAME:string
+export const SETTINGS_BACKEND_EXTENSION_POINT_NAME:string
 export const TLS_BACKEND_EXTENSION_POINT_NAME:string
 export const TLS_DATABASE_PURPOSE_AUTHENTICATE_CLIENT:string
 export const TLS_DATABASE_PURPOSE_AUTHENTICATE_SERVER:string
@@ -657,9 +661,11 @@ export function app_info_get_default_for_uri_scheme(uri_scheme: string): AppInfo
 export function app_info_get_fallback_for_type(content_type: string): GLib.List
 export function app_info_get_recommended_for_type(content_type: string): GLib.List
 export function app_info_launch_default_for_uri(uri: string, launch_context: AppLaunchContext | null): boolean
+export function app_info_launch_default_for_uri_async(uri: string, launch_context: AppLaunchContext, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+export function app_info_launch_default_for_uri_finish(result: AsyncResult): boolean
 export function app_info_reset_type_associations(content_type: string): void
-export function async_initable_newv_async(object_type: number, n_parameters: number, parameters: GObject.Parameter, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
-export function bus_get(bus_type: BusType, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+export function async_initable_newv_async(object_type: number, n_parameters: number, parameters: GObject.Parameter, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+export function bus_get(bus_type: BusType, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
 export function bus_get_finish(res: AsyncResult): DBusConnection
 export function bus_get_sync(bus_type: BusType, cancellable: Cancellable | null): DBusConnection
 export function bus_own_name_on_connection_with_closures(connection: DBusConnection, name: string, flags: BusNameOwnerFlags, name_acquired_closure: Function, name_lost_closure: Function): number
@@ -672,20 +678,21 @@ export function content_type_can_be_executable(type: string): boolean
 export function content_type_equals(type1: string, type2: string): boolean
 export function content_type_from_mime_type(mime_type: string): string | null
 export function content_type_get_description(type: string): string
-export function content_type_get_generic_icon_name(type: string): string
+export function content_type_get_generic_icon_name(type: string): string | null
 export function content_type_get_icon(type: string): Icon
 export function content_type_get_mime_type(type: string): string | null
 export function content_type_get_symbolic_icon(type: string): Icon
 export function content_type_guess(filename: string | null, data: Gjs.byteArray.ByteArray | null): [ /* returnType */ string, /* result_uncertain */ boolean | null ]
 export function content_type_guess_for_tree(root: File): string[]
 export function content_type_is_a(type: string, supertype: string): boolean
+export function content_type_is_mime_type(type: string, mime_type: string): boolean
 export function content_type_is_unknown(type: string): boolean
 export function content_types_get_registered(): GLib.List
 export function dbus_address_escape_value(string: string): string
 export function dbus_address_get_for_bus_sync(bus_type: BusType, cancellable: Cancellable | null): string
-export function dbus_address_get_stream(address: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
-export function dbus_address_get_stream_finish(res: AsyncResult, out_guid: string): IOStream
-export function dbus_address_get_stream_sync(address: string, out_guid: string, cancellable: Cancellable | null): IOStream
+export function dbus_address_get_stream(address: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+export function dbus_address_get_stream_finish(res: AsyncResult): [ /* returnType */ IOStream, /* out_guid */ string | null ]
+export function dbus_address_get_stream_sync(address: string, cancellable: Cancellable | null): [ /* returnType */ IOStream, /* out_guid */ string | null ]
 export function dbus_annotation_info_lookup(annotations: DBusAnnotationInfo[] | null, name: string): string
 export function dbus_error_encode_gerror(error: GLib.Error): string
 export function dbus_error_get_remote_error(error: GLib.Error): string
@@ -706,6 +713,8 @@ export function dbus_is_member_name(string: string): boolean
 export function dbus_is_name(string: string): boolean
 export function dbus_is_supported_address(string: string): boolean
 export function dbus_is_unique_name(string: string): boolean
+export function dtls_client_connection_new(base_socket: DatagramBased, server_identity: SocketConnectable | null): DtlsClientConnection
+export function dtls_server_connection_new(base_socket: DatagramBased, certificate: TlsCertificate | null): DtlsServerConnection
 export function file_new_for_commandline_arg(arg: string): File
 export function file_new_for_commandline_arg_and_cwd(arg: string, cwd: string): File
 export function file_new_for_path(path: string): File
@@ -726,9 +735,12 @@ export function io_modules_load_all_in_directory_with_scope(dirname: string, sco
 export function io_modules_scan_all_in_directory(dirname: string): void
 export function io_modules_scan_all_in_directory_with_scope(dirname: string, scope: IOModuleScope): void
 export function io_scheduler_cancel_all_jobs(): void
-export function io_scheduler_push_job(job_func: IOSchedulerJobFunc, user_data: object, notify: GLib.DestroyNotify | null, io_priority: number, cancellable: Cancellable | null): void
+export function io_scheduler_push_job(job_func: IOSchedulerJobFunc, user_data: object | null, notify: GLib.DestroyNotify | null, io_priority: number, cancellable: Cancellable | null): void
+export function keyfile_settings_backend_new(filename: string, root_path: string, root_group: string | null): SettingsBackend
+export function memory_settings_backend_new(): SettingsBackend
 export function network_monitor_get_default(): NetworkMonitor
 export function networking_init(): void
+export function null_settings_backend_new(): SettingsBackend
 export function pollable_source_new(pollable_stream: GObject.Object): GLib.Source
 export function pollable_source_new_full(pollable_stream: GObject.Object, child_source: GLib.Source | null, cancellable: Cancellable | null): GLib.Source
 export function pollable_stream_read(stream: InputStream, buffer: Gjs.byteArray.ByteArray, blocking: boolean, cancellable: Cancellable | null): number
@@ -746,7 +758,7 @@ export function resources_open_stream(path: string, lookup_flags: ResourceLookup
 export function resources_register(resource: Resource): void
 export function resources_unregister(resource: Resource): void
 export function settings_schema_source_get_default(): SettingsSchemaSource
-export function simple_async_report_gerror_in_idle(object: GObject.Object | null, callback: AsyncReadyCallback | null, user_data: object, error: GLib.Error): void
+export function simple_async_report_gerror_in_idle(object: GObject.Object | null, callback: AsyncReadyCallback | null, user_data: object | null, error: GLib.Error): void
 export function tls_backend_get_default(): TlsBackend
 export function tls_client_connection_new(base_io_stream: IOStream, server_identity: SocketConnectable | null): TlsClientConnection
 export function tls_error_quark(): GLib.Quark
@@ -768,88 +780,94 @@ export function unix_mount_is_system_internal(mount_entry: UnixMountEntry): bool
 export function unix_mount_points_changed_since(time: number): boolean
 export function unix_mounts_changed_since(time: number): boolean
 export interface AsyncReadyCallback {
-    (source_object: GObject.Object, res: AsyncResult, user_data: object): void
+    (source_object: GObject.Object, res: AsyncResult, user_data: object | null): void
 }
 export interface BusAcquiredCallback {
-    (connection: DBusConnection, name: string, user_data: object): void
+    (connection: DBusConnection, name: string, user_data: object | null): void
 }
 export interface BusNameAcquiredCallback {
-    (connection: DBusConnection, name: string, user_data: object): void
+    (connection: DBusConnection, name: string, user_data: object | null): void
 }
 export interface BusNameAppearedCallback {
-    (connection: DBusConnection, name: string, name_owner: string, user_data: object): void
+    (connection: DBusConnection, name: string, name_owner: string, user_data: object | null): void
 }
 export interface BusNameLostCallback {
-    (connection: DBusConnection, name: string, user_data: object): void
+    (connection: DBusConnection, name: string, user_data: object | null): void
 }
 export interface BusNameVanishedCallback {
-    (connection: DBusConnection, name: string, user_data: object): void
+    (connection: DBusConnection, name: string, user_data: object | null): void
 }
 export interface CancellableSourceFunc {
-    (cancellable: Cancellable | null, user_data: object): boolean
+    (cancellable: Cancellable | null, user_data: object | null): boolean
 }
 export interface DBusInterfaceGetPropertyFunc {
-    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, property_name: string, error: GLib.Error, user_data: object): GLib.Variant
+    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, property_name: string, error: GLib.Error, user_data: object | null): GLib.Variant
 }
 export interface DBusInterfaceMethodCallFunc {
-    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant, invocation: DBusMethodInvocation, user_data: object): void
+    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant, invocation: DBusMethodInvocation, user_data: object | null): void
 }
 export interface DBusInterfaceSetPropertyFunc {
-    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, property_name: string, value: GLib.Variant, error: GLib.Error, user_data: object): boolean
+    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, property_name: string, value: GLib.Variant, error: GLib.Error, user_data: object | null): boolean
 }
 export interface DBusMessageFilterFunction {
-    (connection: DBusConnection, message: DBusMessage, incoming: boolean, user_data: object): DBusMessage
+    (connection: DBusConnection, message: DBusMessage, incoming: boolean, user_data: object | null): DBusMessage | null
 }
 export interface DBusProxyTypeFunc {
-    (manager: DBusObjectManagerClient, object_path: string, interface_name: string | null, user_data: object): number
+    (manager: DBusObjectManagerClient, object_path: string, interface_name: string | null, user_data: object | null): number
 }
 export interface DBusSignalCallback {
-    (connection: DBusConnection, sender_name: string, object_path: string, interface_name: string, signal_name: string, parameters: GLib.Variant, user_data: object): void
+    (connection: DBusConnection, sender_name: string, object_path: string, interface_name: string, signal_name: string, parameters: GLib.Variant, user_data: object | null): void
 }
 export interface DBusSubtreeDispatchFunc {
-    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, node: string, out_user_data: object | null, user_data: object): DBusInterfaceVTable
+    (connection: DBusConnection, sender: string, object_path: string, interface_name: string, node: string, out_user_data: object, user_data: object | null): DBusInterfaceVTable
 }
 export interface DBusSubtreeIntrospectFunc {
-    (connection: DBusConnection, sender: string, object_path: string, node: string, user_data: object): DBusInterfaceInfo
+    (connection: DBusConnection, sender: string, object_path: string, node: string, user_data: object | null): DBusInterfaceInfo
 }
 export interface DatagramBasedSourceFunc {
-    (datagram_based: DatagramBased, condition: GLib.IOCondition, user_data: object): boolean
+    (datagram_based: DatagramBased, condition: GLib.IOCondition, user_data: object | null): boolean
 }
 export interface DesktopAppLaunchCallback {
-    (appinfo: DesktopAppInfo, pid: GLib.Pid, user_data: object): void
+    (appinfo: DesktopAppInfo, pid: GLib.Pid, user_data: object | null): void
 }
 export interface FileMeasureProgressCallback {
-    (reporting: boolean, current_size: number, num_dirs: number, num_files: number, user_data: object): void
+    (reporting: boolean, current_size: number, num_dirs: number, num_files: number, user_data: object | null): void
 }
 export interface FileProgressCallback {
-    (current_num_bytes: number, total_num_bytes: number, user_data: object): void
+    (current_num_bytes: number, total_num_bytes: number, user_data: object | null): void
 }
 export interface FileReadMoreCallback {
-    (file_contents: string, file_size: number, callback_data: object): boolean
+    (file_contents: string, file_size: number, callback_data: object | null): boolean
 }
 export interface IOSchedulerJobFunc {
-    (job: IOSchedulerJob, cancellable: Cancellable | null, user_data: object): boolean
+    (job: IOSchedulerJob, cancellable: Cancellable | null, user_data: object | null): boolean
 }
 export interface PollableSourceFunc {
-    (pollable_stream: GObject.Object, user_data: object): boolean
+    (pollable_stream: GObject.Object, user_data: object | null): boolean
+}
+export interface ReallocFunc {
+    (data: object | null, size: number): object | null
 }
 export interface SettingsBindGetMapping {
-    (value: any, variant: GLib.Variant, user_data: object): boolean
+    (value: any, variant: GLib.Variant, user_data: object | null): boolean
 }
 export interface SettingsBindSetMapping {
-    (value: any, expected_type: GLib.VariantType, user_data: object): GLib.Variant
+    (value: any, expected_type: GLib.VariantType, user_data: object | null): GLib.Variant
 }
 export interface SettingsGetMapping {
-    (value: GLib.Variant, user_data: object): boolean
+    (value: GLib.Variant, user_data: object | null): boolean
 }
 export interface SimpleAsyncThreadFunc {
     (res: SimpleAsyncResult, object: GObject.Object, cancellable: Cancellable | null): void
 }
 export interface SocketSourceFunc {
-    (socket: Socket, condition: GLib.IOCondition, user_data: object): boolean
+    (socket: Socket, condition: GLib.IOCondition, user_data: object | null): boolean
 }
 export interface TaskThreadFunc {
-    (task: Task, source_object: GObject.Object, task_data: object, cancellable: Cancellable | null): void
+    (task: Task, source_object: GObject.Object, task_data: object | null, cancellable: Cancellable | null): void
+}
+export interface VfsFileLookupFunc {
+    (vfs: Vfs, identifier: string, user_data: object | null): File
 }
 export interface Action {
     /* Properties of Gio.Action */
@@ -863,19 +881,19 @@ export interface Action {
     change_state(value: GLib.Variant): void
     get_enabled(): boolean
     get_name(): string
-    get_parameter_type(): GLib.VariantType
+    get_parameter_type(): GLib.VariantType | null
     get_state(): GLib.Variant
     get_state_hint(): GLib.Variant | null
-    get_state_type(): GLib.VariantType
+    get_state_type(): GLib.VariantType | null
     /* Virtual methods of Gio.Action */
     vfunc_activate(parameter: GLib.Variant | null): void
     vfunc_change_state(value: GLib.Variant): void
     vfunc_get_enabled(): boolean
     vfunc_get_name(): string
-    vfunc_get_parameter_type(): GLib.VariantType
+    vfunc_get_parameter_type(): GLib.VariantType | null
     vfunc_get_state(): GLib.Variant
     vfunc_get_state_hint(): GLib.Variant | null
-    vfunc_get_state_type(): GLib.VariantType
+    vfunc_get_state_type(): GLib.VariantType | null
 }
 export interface Action_Static {
     name: string
@@ -930,7 +948,7 @@ export declare var ActionGroup: ActionGroup_Static
 export interface ActionMap {
     /* Methods of Gio.ActionMap */
     add_action(action: Action): void
-    add_action_entries(entries: ActionEntry[], user_data: object): void
+    add_action_entries(entries: ActionEntry[], user_data: object | null): void
     lookup_action(action_name: string): Action
     remove_action(action_name: string): void
     /* Virtual methods of Gio.ActionMap */
@@ -1004,35 +1022,37 @@ export declare class AppInfo_Static {
     get_fallback_for_type(content_type: string): GLib.List
     get_recommended_for_type(content_type: string): GLib.List
     launch_default_for_uri(uri: string, launch_context: AppLaunchContext | null): boolean
+    launch_default_for_uri_async(uri: string, launch_context: AppLaunchContext, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    launch_default_for_uri_finish(result: AsyncResult): boolean
     reset_type_associations(content_type: string): void
 }
 export declare var AppInfo: AppInfo_Static
 export interface AsyncInitable {
     /* Methods of Gio.AsyncInitable */
-    init_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    init_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     init_finish(res: AsyncResult): boolean
     new_finish(res: AsyncResult): GObject.Object
     /* Virtual methods of Gio.AsyncInitable */
-    vfunc_init_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_init_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_init_finish(res: AsyncResult): boolean
 }
 export interface AsyncInitable_Static {
     name: string
 }
 export declare class AsyncInitable_Static {
-    newv_async(object_type: number, n_parameters: number, parameters: GObject.Parameter, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    newv_async(object_type: number, n_parameters: number, parameters: GObject.Parameter, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
 }
 export declare var AsyncInitable: AsyncInitable_Static
 export interface AsyncResult {
     /* Methods of Gio.AsyncResult */
     get_source_object(): GObject.Object
-    get_user_data(): object
-    is_tagged(source_tag: object): boolean
+    get_user_data(): object | null
+    is_tagged(source_tag: object | null): boolean
     legacy_propagate_error(): boolean
     /* Virtual methods of Gio.AsyncResult */
     vfunc_get_source_object(): GObject.Object
-    vfunc_get_user_data(): object
-    vfunc_is_tagged(source_tag: object): boolean
+    vfunc_get_user_data(): object | null
+    vfunc_is_tagged(source_tag: object | null): boolean
 }
 export interface AsyncResult_Static {
     name: string
@@ -1040,10 +1060,10 @@ export interface AsyncResult_Static {
 export declare var AsyncResult: AsyncResult_Static
 export interface Converter {
     /* Methods of Gio.Converter */
-    convert(inbuf: Gjs.byteArray.ByteArray, outbuf: object, outbuf_size: number, flags: ConverterFlags): [ /* returnType */ ConverterResult, /* bytes_read */ number, /* bytes_written */ number ]
+    convert(inbuf: Gjs.byteArray.ByteArray, outbuf: Gjs.byteArray.ByteArray, flags: ConverterFlags): [ /* returnType */ ConverterResult, /* bytes_read */ number, /* bytes_written */ number ]
     reset(): void
     /* Virtual methods of Gio.Converter */
-    vfunc_convert(inbuf: Gjs.byteArray.ByteArray, outbuf: object, outbuf_size: number, flags: ConverterFlags): [ /* returnType */ ConverterResult, /* bytes_read */ number, /* bytes_written */ number ]
+    vfunc_convert(inbuf: Gjs.byteArray.ByteArray | null, outbuf: Gjs.byteArray.ByteArray | null, flags: ConverterFlags): [ /* returnType */ ConverterResult, /* bytes_read */ number, /* bytes_written */ number ]
     vfunc_reset(): void
 }
 export interface Converter_Static {
@@ -1113,14 +1133,14 @@ export interface DatagramBased {
     condition_check(condition: GLib.IOCondition): GLib.IOCondition
     condition_wait(condition: GLib.IOCondition, timeout: number, cancellable: Cancellable | null): boolean
     create_source(condition: GLib.IOCondition, cancellable: Cancellable | null): GLib.Source
-    receive_messages(messages: InputMessage, num_messages: number, flags: number, timeout: number, cancellable: Cancellable | null): number
-    send_messages(messages: OutputMessage, num_messages: number, flags: number, timeout: number, cancellable: Cancellable | null): number
+    receive_messages(messages: InputMessage[], flags: number, timeout: number, cancellable: Cancellable | null): number
+    send_messages(messages: OutputMessage[], flags: number, timeout: number, cancellable: Cancellable | null): number
     /* Virtual methods of Gio.DatagramBased */
     vfunc_condition_check(condition: GLib.IOCondition): GLib.IOCondition
     vfunc_condition_wait(condition: GLib.IOCondition, timeout: number, cancellable: Cancellable | null): boolean
     vfunc_create_source(condition: GLib.IOCondition, cancellable: Cancellable | null): GLib.Source
-    vfunc_receive_messages(messages: InputMessage, num_messages: number, flags: number, timeout: number, cancellable: Cancellable | null): number
-    vfunc_send_messages(messages: OutputMessage, num_messages: number, flags: number, timeout: number, cancellable: Cancellable | null): number
+    vfunc_receive_messages(messages: InputMessage[], flags: number, timeout: number, cancellable: Cancellable | null): number
+    vfunc_send_messages(messages: OutputMessage[], flags: number, timeout: number, cancellable: Cancellable | null): number
 }
 export interface DatagramBased_Static {
     name: string
@@ -1143,9 +1163,9 @@ export interface Drive {
     can_start(): boolean
     can_start_degraded(): boolean
     can_stop(): boolean
-    eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_finish(result: AsyncResult): boolean
-    eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_with_operation_finish(result: AsyncResult): boolean
     enumerate_identifiers(): string[]
     get_icon(): Icon
@@ -1159,11 +1179,12 @@ export interface Drive {
     has_volumes(): boolean
     is_media_check_automatic(): boolean
     is_media_removable(): boolean
-    poll_for_media(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    is_removable(): boolean
+    poll_for_media(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     poll_for_media_finish(result: AsyncResult): boolean
-    start(flags: DriveStartFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    start(flags: DriveStartFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     start_finish(result: AsyncResult): boolean
-    stop(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    stop(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     stop_finish(result: AsyncResult): boolean
     /* Virtual methods of Gio.Drive */
     vfunc_can_eject(): boolean
@@ -1173,10 +1194,10 @@ export interface Drive {
     vfunc_can_stop(): boolean
     vfunc_changed(): void
     vfunc_disconnected(): void
-    vfunc_eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_button(): void
     vfunc_eject_finish(result: AsyncResult): boolean
-    vfunc_eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_with_operation_finish(result: AsyncResult): boolean
     vfunc_enumerate_identifiers(): string[]
     vfunc_get_icon(): Icon
@@ -1190,11 +1211,12 @@ export interface Drive {
     vfunc_has_volumes(): boolean
     vfunc_is_media_check_automatic(): boolean
     vfunc_is_media_removable(): boolean
-    vfunc_poll_for_media(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_is_removable(): boolean
+    vfunc_poll_for_media(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_poll_for_media_finish(result: AsyncResult): boolean
-    vfunc_start(flags: DriveStartFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_start(flags: DriveStartFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_start_finish(result: AsyncResult): boolean
-    vfunc_stop(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_stop(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_stop_button(): void
     vfunc_stop_finish(result: AsyncResult): boolean
     /* Signals of Gio.Drive */
@@ -1207,42 +1229,119 @@ export interface Drive_Static {
     name: string
 }
 export declare var Drive: Drive_Static
+export interface DtlsClientConnection {
+    /* Properties of Gio.DtlsClientConnection */
+    readonly accepted_cas:GLib.List
+    server_identity:SocketConnectable
+    validation_flags:TlsCertificateFlags
+    /* Methods of Gio.DtlsClientConnection */
+    get_accepted_cas(): GLib.List
+    get_server_identity(): SocketConnectable
+    get_validation_flags(): TlsCertificateFlags
+    set_server_identity(identity: SocketConnectable): void
+    set_validation_flags(flags: TlsCertificateFlags): void
+}
+export interface DtlsClientConnection_Static {
+    name: string
+}
+export declare class DtlsClientConnection_Static {
+    new(base_socket: DatagramBased, server_identity: SocketConnectable | null): DtlsClientConnection
+}
+export declare var DtlsClientConnection: DtlsClientConnection_Static
+export interface DtlsConnection {
+    /* Properties of Gio.DtlsConnection */
+    certificate:TlsCertificate
+    database:TlsDatabase
+    interaction:TlsInteraction
+    readonly peer_certificate:TlsCertificate
+    readonly peer_certificate_errors:TlsCertificateFlags
+    rehandshake_mode:TlsRehandshakeMode
+    require_close_notify:boolean
+    /* Methods of Gio.DtlsConnection */
+    close(cancellable: Cancellable | null): boolean
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    close_finish(result: AsyncResult): boolean
+    emit_accept_certificate(peer_cert: TlsCertificate, errors: TlsCertificateFlags): boolean
+    get_certificate(): TlsCertificate
+    get_database(): TlsDatabase
+    get_interaction(): TlsInteraction
+    get_peer_certificate(): TlsCertificate
+    get_peer_certificate_errors(): TlsCertificateFlags
+    get_rehandshake_mode(): TlsRehandshakeMode
+    get_require_close_notify(): boolean
+    handshake(cancellable: Cancellable | null): boolean
+    handshake_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    handshake_finish(result: AsyncResult): boolean
+    set_certificate(certificate: TlsCertificate): void
+    set_database(database: TlsDatabase): void
+    set_interaction(interaction: TlsInteraction | null): void
+    set_rehandshake_mode(mode: TlsRehandshakeMode): void
+    set_require_close_notify(require_close_notify: boolean): void
+    shutdown(shutdown_read: boolean, shutdown_write: boolean, cancellable: Cancellable | null): boolean
+    shutdown_async(shutdown_read: boolean, shutdown_write: boolean, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    shutdown_finish(result: AsyncResult): boolean
+    /* Virtual methods of Gio.DtlsConnection */
+    vfunc_accept_certificate(peer_cert: TlsCertificate, errors: TlsCertificateFlags): boolean
+    vfunc_handshake(cancellable: Cancellable | null): boolean
+    vfunc_handshake_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    vfunc_handshake_finish(result: AsyncResult): boolean
+    vfunc_shutdown(shutdown_read: boolean, shutdown_write: boolean, cancellable: Cancellable | null): boolean
+    vfunc_shutdown_async(shutdown_read: boolean, shutdown_write: boolean, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    vfunc_shutdown_finish(result: AsyncResult): boolean
+    /* Signals of Gio.DtlsConnection */
+    connect(sigName: "accept-certificate", callback: ((obj: DtlsConnection, peer_cert: TlsCertificate, errors: TlsCertificateFlags) => boolean))
+}
+export interface DtlsConnection_Static {
+    name: string
+}
+export declare var DtlsConnection: DtlsConnection_Static
+export interface DtlsServerConnection {
+    /* Properties of Gio.DtlsServerConnection */
+    authentication_mode:TlsAuthenticationMode
+}
+export interface DtlsServerConnection_Static {
+    name: string
+}
+export declare class DtlsServerConnection_Static {
+    new(base_socket: DatagramBased, certificate: TlsCertificate | null): DtlsServerConnection
+}
+export declare var DtlsServerConnection: DtlsServerConnection_Static
 export interface File {
     /* Methods of Gio.File */
     append_to(flags: FileCreateFlags, cancellable: Cancellable | null): FileOutputStream
-    append_to_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    append_to_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     append_to_finish(res: AsyncResult): FileOutputStream
-    copy(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object): boolean
+    copy(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object | null): boolean
     copy_attributes(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null): boolean
     copy_finish(res: AsyncResult): boolean
     create(flags: FileCreateFlags, cancellable: Cancellable | null): FileOutputStream
-    create_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    create_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     create_finish(res: AsyncResult): FileOutputStream
     create_readwrite(flags: FileCreateFlags, cancellable: Cancellable | null): FileIOStream
-    create_readwrite_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    create_readwrite_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     create_readwrite_finish(res: AsyncResult): FileIOStream
     delete(cancellable: Cancellable | null): boolean
-    delete_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    delete_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     delete_finish(result: AsyncResult): boolean
     dup(): File
-    eject_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_mountable_finish(result: AsyncResult): boolean
-    eject_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_mountable_with_operation_finish(result: AsyncResult): boolean
     enumerate_children(attributes: string, flags: FileQueryInfoFlags, cancellable: Cancellable | null): FileEnumerator
-    enumerate_children_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    enumerate_children_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     enumerate_children_finish(res: AsyncResult): FileEnumerator
     equal(file2: File): boolean
     find_enclosing_mount(cancellable: Cancellable | null): Mount
-    find_enclosing_mount_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    find_enclosing_mount_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     find_enclosing_mount_finish(res: AsyncResult): Mount
-    get_basename(): string | null
+    get_basename(): string
     get_child(name: string): File
     get_child_for_display_name(display_name: string): File
     get_parent(): File | null
     get_parse_name(): string
-    get_path(): string | null
-    get_relative_path(descendant: File): string | null
+    get_path(): string
+    get_relative_path(descendant: File): string
     get_uri(): string
     get_uri_scheme(): string
     has_parent(parent: File | null): boolean
@@ -1251,11 +1350,11 @@ export interface File {
     hash(): number
     is_native(): boolean
     load_contents(cancellable: Cancellable | null): [ /* returnType */ boolean, /* contents */ Gjs.byteArray.ByteArray, /* etag_out */ string | null ]
-    load_contents_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    load_contents_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     load_contents_finish(res: AsyncResult): [ /* returnType */ boolean, /* contents */ Gjs.byteArray.ByteArray, /* etag_out */ string | null ]
     load_partial_contents_finish(res: AsyncResult): [ /* returnType */ boolean, /* contents */ Gjs.byteArray.ByteArray, /* etag_out */ string | null ]
     make_directory(cancellable: Cancellable | null): boolean
-    make_directory_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    make_directory_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     make_directory_finish(result: AsyncResult): boolean
     make_directory_with_parents(cancellable: Cancellable | null): boolean
     make_symbolic_link(symlink_value: string, cancellable: Cancellable | null): boolean
@@ -1263,39 +1362,39 @@ export interface File {
     monitor(flags: FileMonitorFlags, cancellable: Cancellable | null): FileMonitor
     monitor_directory(flags: FileMonitorFlags, cancellable: Cancellable | null): FileMonitor
     monitor_file(flags: FileMonitorFlags, cancellable: Cancellable | null): FileMonitor
-    mount_enclosing_volume(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    mount_enclosing_volume(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     mount_enclosing_volume_finish(result: AsyncResult): boolean
-    mount_mountable(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    mount_mountable(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     mount_mountable_finish(result: AsyncResult): File
-    move(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object): boolean
+    move(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object | null): boolean
     open_readwrite(cancellable: Cancellable | null): FileIOStream
-    open_readwrite_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    open_readwrite_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     open_readwrite_finish(res: AsyncResult): FileIOStream
-    poll_mountable(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    poll_mountable(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     poll_mountable_finish(result: AsyncResult): boolean
     query_default_handler(cancellable: Cancellable | null): AppInfo
     query_exists(cancellable: Cancellable | null): boolean
     query_file_type(flags: FileQueryInfoFlags, cancellable: Cancellable | null): FileType
     query_filesystem_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    query_filesystem_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    query_filesystem_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     query_filesystem_info_finish(res: AsyncResult): FileInfo
     query_info(attributes: string, flags: FileQueryInfoFlags, cancellable: Cancellable | null): FileInfo
-    query_info_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    query_info_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     query_info_finish(res: AsyncResult): FileInfo
     query_settable_attributes(cancellable: Cancellable | null): FileAttributeInfoList
     query_writable_namespaces(cancellable: Cancellable | null): FileAttributeInfoList
     read(cancellable: Cancellable | null): FileInputStream
-    read_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_finish(res: AsyncResult): FileInputStream
     replace(etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null): FileOutputStream
-    replace_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    replace_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     replace_contents(contents: Gjs.byteArray.ByteArray, etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null): [ /* returnType */ boolean, /* new_etag */ string | null ]
-    replace_contents_async(contents: Gjs.byteArray.ByteArray, etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
-    replace_contents_bytes_async(contents: Gjs.byteArray.ByteArray, etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    replace_contents_async(contents: Gjs.byteArray.ByteArray, etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    replace_contents_bytes_async(contents: Gjs.byteArray.ByteArray, etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     replace_contents_finish(res: AsyncResult): [ /* returnType */ boolean, /* new_etag */ string | null ]
     replace_finish(res: AsyncResult): FileOutputStream
     replace_readwrite(etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null): FileIOStream
-    replace_readwrite_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    replace_readwrite_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     replace_readwrite_finish(res: AsyncResult): FileIOStream
     resolve_relative_path(relative_path: string): File
     set_attribute(attribute: string, type: FileAttributeType, value_p: object | null, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
@@ -1305,115 +1404,115 @@ export interface File {
     set_attribute_string(attribute: string, value: string, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
     set_attribute_uint32(attribute: string, value: number, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
     set_attribute_uint64(attribute: string, value: number, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
-    set_attributes_async(info: FileInfo, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    set_attributes_async(info: FileInfo, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     set_attributes_finish(result: AsyncResult): [ /* returnType */ boolean, /* info */ FileInfo ]
     set_attributes_from_info(info: FileInfo, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
     set_display_name(display_name: string, cancellable: Cancellable | null): File
-    set_display_name_async(display_name: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    set_display_name_async(display_name: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     set_display_name_finish(res: AsyncResult): File
-    start_mountable(flags: DriveStartFlags, start_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    start_mountable(flags: DriveStartFlags, start_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     start_mountable_finish(result: AsyncResult): boolean
-    stop_mountable(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    stop_mountable(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     stop_mountable_finish(result: AsyncResult): boolean
     supports_thread_contexts(): boolean
     trash(cancellable: Cancellable | null): boolean
-    trash_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    trash_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     trash_finish(result: AsyncResult): boolean
-    unmount_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    unmount_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     unmount_mountable_finish(result: AsyncResult): boolean
-    unmount_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    unmount_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     unmount_mountable_with_operation_finish(result: AsyncResult): boolean
     /* Virtual methods of Gio.File */
     vfunc_append_to(flags: FileCreateFlags, cancellable: Cancellable | null): FileOutputStream
-    vfunc_append_to_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_append_to_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_append_to_finish(res: AsyncResult): FileOutputStream
-    vfunc_copy(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object): boolean
+    vfunc_copy(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object | null): boolean
     vfunc_copy_finish(res: AsyncResult): boolean
     vfunc_create(flags: FileCreateFlags, cancellable: Cancellable | null): FileOutputStream
-    vfunc_create_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_create_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_create_finish(res: AsyncResult): FileOutputStream
     vfunc_create_readwrite(flags: FileCreateFlags, cancellable: Cancellable | null): FileIOStream
-    vfunc_create_readwrite_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_create_readwrite_async(flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_create_readwrite_finish(res: AsyncResult): FileIOStream
     vfunc_delete_file(cancellable: Cancellable | null): boolean
-    vfunc_delete_file_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_delete_file_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_delete_file_finish(result: AsyncResult): boolean
     vfunc_dup(): File
-    vfunc_eject_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_mountable_finish(result: AsyncResult): boolean
-    vfunc_eject_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_mountable_with_operation_finish(result: AsyncResult): boolean
     vfunc_enumerate_children(attributes: string, flags: FileQueryInfoFlags, cancellable: Cancellable | null): FileEnumerator
-    vfunc_enumerate_children_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_enumerate_children_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_enumerate_children_finish(res: AsyncResult): FileEnumerator
     vfunc_equal(file2: File): boolean
     vfunc_find_enclosing_mount(cancellable: Cancellable | null): Mount
-    vfunc_find_enclosing_mount_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_find_enclosing_mount_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_find_enclosing_mount_finish(res: AsyncResult): Mount
-    vfunc_get_basename(): string | null
+    vfunc_get_basename(): string
     vfunc_get_child_for_display_name(display_name: string): File
     vfunc_get_parent(): File | null
     vfunc_get_parse_name(): string
-    vfunc_get_path(): string | null
-    vfunc_get_relative_path(descendant: File): string | null
+    vfunc_get_path(): string
+    vfunc_get_relative_path(descendant: File): string
     vfunc_get_uri(): string
     vfunc_get_uri_scheme(): string
     vfunc_has_uri_scheme(uri_scheme: string): boolean
     vfunc_hash(): number
     vfunc_is_native(): boolean
     vfunc_make_directory(cancellable: Cancellable | null): boolean
-    vfunc_make_directory_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_make_directory_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_make_directory_finish(result: AsyncResult): boolean
     vfunc_make_symbolic_link(symlink_value: string, cancellable: Cancellable | null): boolean
     vfunc_measure_disk_usage_finish(result: AsyncResult): [ /* returnType */ boolean, /* disk_usage */ number | null, /* num_dirs */ number | null, /* num_files */ number | null ]
     vfunc_monitor_dir(flags: FileMonitorFlags, cancellable: Cancellable | null): FileMonitor
     vfunc_monitor_file(flags: FileMonitorFlags, cancellable: Cancellable | null): FileMonitor
-    vfunc_mount_enclosing_volume(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_mount_enclosing_volume(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_mount_enclosing_volume_finish(result: AsyncResult): boolean
-    vfunc_mount_mountable(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_mount_mountable(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_mount_mountable_finish(result: AsyncResult): File
-    vfunc_move(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object): boolean
+    vfunc_move(destination: File, flags: FileCopyFlags, cancellable: Cancellable | null, progress_callback: FileProgressCallback | null, progress_callback_data: object | null): boolean
     vfunc_open_readwrite(cancellable: Cancellable | null): FileIOStream
-    vfunc_open_readwrite_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_open_readwrite_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_open_readwrite_finish(res: AsyncResult): FileIOStream
-    vfunc_poll_mountable(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_poll_mountable(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_poll_mountable_finish(result: AsyncResult): boolean
     vfunc_prefix_matches(file: File): boolean
     vfunc_query_filesystem_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    vfunc_query_filesystem_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_query_filesystem_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_query_filesystem_info_finish(res: AsyncResult): FileInfo
     vfunc_query_info(attributes: string, flags: FileQueryInfoFlags, cancellable: Cancellable | null): FileInfo
-    vfunc_query_info_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_query_info_async(attributes: string, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_query_info_finish(res: AsyncResult): FileInfo
     vfunc_query_settable_attributes(cancellable: Cancellable | null): FileAttributeInfoList
     vfunc_query_writable_namespaces(cancellable: Cancellable | null): FileAttributeInfoList
-    vfunc_read_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(res: AsyncResult): FileInputStream
     vfunc_read_fn(cancellable: Cancellable | null): FileInputStream
     vfunc_replace(etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null): FileOutputStream
-    vfunc_replace_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_replace_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_replace_finish(res: AsyncResult): FileOutputStream
     vfunc_replace_readwrite(etag: string | null, make_backup: boolean, flags: FileCreateFlags, cancellable: Cancellable | null): FileIOStream
-    vfunc_replace_readwrite_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_replace_readwrite_async(etag: string | null, make_backup: boolean, flags: FileCreateFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_replace_readwrite_finish(res: AsyncResult): FileIOStream
     vfunc_resolve_relative_path(relative_path: string): File
     vfunc_set_attribute(attribute: string, type: FileAttributeType, value_p: object | null, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
-    vfunc_set_attributes_async(info: FileInfo, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_set_attributes_async(info: FileInfo, flags: FileQueryInfoFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_set_attributes_finish(result: AsyncResult): [ /* returnType */ boolean, /* info */ FileInfo ]
     vfunc_set_attributes_from_info(info: FileInfo, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
     vfunc_set_display_name(display_name: string, cancellable: Cancellable | null): File
-    vfunc_set_display_name_async(display_name: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_set_display_name_async(display_name: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_set_display_name_finish(res: AsyncResult): File
-    vfunc_start_mountable(flags: DriveStartFlags, start_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_start_mountable(flags: DriveStartFlags, start_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_start_mountable_finish(result: AsyncResult): boolean
-    vfunc_stop_mountable(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_stop_mountable(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_stop_mountable_finish(result: AsyncResult): boolean
     vfunc_trash(cancellable: Cancellable | null): boolean
-    vfunc_trash_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_trash_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_trash_finish(result: AsyncResult): boolean
-    vfunc_unmount_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_unmount_mountable(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_unmount_mountable_finish(result: AsyncResult): boolean
-    vfunc_unmount_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_unmount_mountable_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_unmount_mountable_with_operation_finish(result: AsyncResult): boolean
 }
 export interface File_Static {
@@ -1477,6 +1576,7 @@ export interface ListModel {
     get_object(position: number): GObject.Object | null
     items_changed(position: number, removed: number, added: number): void
     /* Virtual methods of Gio.ListModel */
+    vfunc_get_item(position: number): object | null
     vfunc_get_item_type(): number
     vfunc_get_n_items(): number
     /* Signals of Gio.ListModel */
@@ -1489,11 +1589,11 @@ export declare var ListModel: ListModel_Static
 export interface LoadableIcon {
     /* Methods of Gio.LoadableIcon */
     load(size: number, cancellable: Cancellable | null): [ /* returnType */ InputStream, /* type */ string | null ]
-    load_async(size: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    load_async(size: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     load_finish(res: AsyncResult): [ /* returnType */ InputStream, /* type */ string | null ]
     /* Virtual methods of Gio.LoadableIcon */
     vfunc_load(size: number, cancellable: Cancellable | null): [ /* returnType */ InputStream, /* type */ string | null ]
-    vfunc_load_async(size: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_load_async(size: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_load_finish(res: AsyncResult): [ /* returnType */ InputStream, /* type */ string | null ]
 }
 export interface LoadableIcon_Static {
@@ -1504,9 +1604,9 @@ export interface Mount {
     /* Methods of Gio.Mount */
     can_eject(): boolean
     can_unmount(): boolean
-    eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_finish(result: AsyncResult): boolean
-    eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_with_operation_finish(result: AsyncResult): boolean
     get_default_location(): File
     get_drive(): Drive
@@ -1517,25 +1617,25 @@ export interface Mount {
     get_symbolic_icon(): Icon
     get_uuid(): string
     get_volume(): Volume
-    guess_content_type(force_rescan: boolean, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    guess_content_type(force_rescan: boolean, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     guess_content_type_finish(result: AsyncResult): string[]
     guess_content_type_sync(force_rescan: boolean, cancellable: Cancellable | null): string[]
     is_shadowed(): boolean
-    remount(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    remount(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     remount_finish(result: AsyncResult): boolean
     shadow(): void
-    unmount(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    unmount(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     unmount_finish(result: AsyncResult): boolean
-    unmount_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    unmount_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     unmount_with_operation_finish(result: AsyncResult): boolean
     unshadow(): void
     /* Virtual methods of Gio.Mount */
     vfunc_can_eject(): boolean
     vfunc_can_unmount(): boolean
     vfunc_changed(): void
-    vfunc_eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_finish(result: AsyncResult): boolean
-    vfunc_eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_with_operation_finish(result: AsyncResult): boolean
     vfunc_get_default_location(): File
     vfunc_get_drive(): Drive
@@ -1546,15 +1646,15 @@ export interface Mount {
     vfunc_get_symbolic_icon(): Icon
     vfunc_get_uuid(): string
     vfunc_get_volume(): Volume
-    vfunc_guess_content_type(force_rescan: boolean, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_guess_content_type(force_rescan: boolean, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_guess_content_type_finish(result: AsyncResult): string[]
     vfunc_guess_content_type_sync(force_rescan: boolean, cancellable: Cancellable | null): string[]
     vfunc_pre_unmount(): void
-    vfunc_remount(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_remount(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_remount_finish(result: AsyncResult): boolean
-    vfunc_unmount(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_unmount(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_unmount_finish(result: AsyncResult): boolean
-    vfunc_unmount_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_unmount_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_unmount_with_operation_finish(result: AsyncResult): boolean
     vfunc_unmounted(): void
     /* Signals of Gio.Mount */
@@ -1573,14 +1673,14 @@ export interface NetworkMonitor {
     readonly network_metered:boolean
     /* Methods of Gio.NetworkMonitor */
     can_reach(connectable: SocketConnectable, cancellable: Cancellable | null): boolean
-    can_reach_async(connectable: SocketConnectable, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    can_reach_async(connectable: SocketConnectable, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     can_reach_finish(result: AsyncResult): boolean
     get_connectivity(): NetworkConnectivity
     get_network_available(): boolean
     get_network_metered(): boolean
     /* Virtual methods of Gio.NetworkMonitor */
     vfunc_can_reach(connectable: SocketConnectable, cancellable: Cancellable | null): boolean
-    vfunc_can_reach_async(connectable: SocketConnectable, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_can_reach_async(connectable: SocketConnectable, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_can_reach_finish(result: AsyncResult): boolean
     vfunc_network_changed(available: boolean): void
     /* Signals of Gio.NetworkMonitor */
@@ -1603,7 +1703,7 @@ export interface PollableInputStream {
     vfunc_can_poll(): boolean
     vfunc_create_source(cancellable: Cancellable | null): GLib.Source
     vfunc_is_readable(): boolean
-    vfunc_read_nonblocking(buffer: Gjs.byteArray.ByteArray): number
+    vfunc_read_nonblocking(buffer: Gjs.byteArray.ByteArray | null): number
 }
 export interface PollableInputStream_Static {
     name: string
@@ -1619,7 +1719,7 @@ export interface PollableOutputStream {
     vfunc_can_poll(): boolean
     vfunc_create_source(cancellable: Cancellable | null): GLib.Source
     vfunc_is_writable(): boolean
-    vfunc_write_nonblocking(buffer: Gjs.byteArray.ByteArray): number
+    vfunc_write_nonblocking(buffer: Gjs.byteArray.ByteArray | null): number
 }
 export interface PollableOutputStream_Static {
     name: string
@@ -1628,12 +1728,12 @@ export declare var PollableOutputStream: PollableOutputStream_Static
 export interface Proxy {
     /* Methods of Gio.Proxy */
     connect(connection: IOStream, proxy_address: ProxyAddress, cancellable: Cancellable | null): IOStream
-    connect_async(connection: IOStream, proxy_address: ProxyAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_async(connection: IOStream, proxy_address: ProxyAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_finish(result: AsyncResult): IOStream
     supports_hostname(): boolean
     /* Virtual methods of Gio.Proxy */
     vfunc_connect(connection: IOStream, proxy_address: ProxyAddress, cancellable: Cancellable | null): IOStream
-    vfunc_connect_async(connection: IOStream, proxy_address: ProxyAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_connect_async(connection: IOStream, proxy_address: ProxyAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_connect_finish(result: AsyncResult): IOStream
     vfunc_supports_hostname(): boolean
 }
@@ -1648,12 +1748,12 @@ export interface ProxyResolver {
     /* Methods of Gio.ProxyResolver */
     is_supported(): boolean
     lookup(uri: string, cancellable: Cancellable | null): string[]
-    lookup_async(uri: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_async(uri: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_finish(result: AsyncResult): string[]
     /* Virtual methods of Gio.ProxyResolver */
     vfunc_is_supported(): boolean
     vfunc_lookup(uri: string, cancellable: Cancellable | null): string[]
-    vfunc_lookup_async(uri: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_async(uri: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_finish(result: AsyncResult): string[]
 }
 export interface ProxyResolver_Static {
@@ -1712,11 +1812,15 @@ export interface TlsBackend {
     get_certificate_type(): number
     get_client_connection_type(): number
     get_default_database(): TlsDatabase
+    get_dtls_client_connection_type(): number
+    get_dtls_server_connection_type(): number
     get_file_database_type(): number
     get_server_connection_type(): number
+    supports_dtls(): boolean
     supports_tls(): boolean
     /* Virtual methods of Gio.TlsBackend */
     vfunc_get_default_database(): TlsDatabase
+    vfunc_supports_dtls(): boolean
     vfunc_supports_tls(): boolean
 }
 export interface TlsBackend_Static {
@@ -1777,9 +1881,9 @@ export interface Volume {
     /* Methods of Gio.Volume */
     can_eject(): boolean
     can_mount(): boolean
-    eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_finish(result: AsyncResult): boolean
-    eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     eject_with_operation_finish(result: AsyncResult): boolean
     enumerate_identifiers(): string[]
     get_activation_root(): File | null
@@ -1791,16 +1895,16 @@ export interface Volume {
     get_sort_key(): string
     get_symbolic_icon(): Icon
     get_uuid(): string
-    mount(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    mount(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     mount_finish(result: AsyncResult): boolean
     should_automount(): boolean
     /* Virtual methods of Gio.Volume */
     vfunc_can_eject(): boolean
     vfunc_can_mount(): boolean
     vfunc_changed(): void
-    vfunc_eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject(flags: MountUnmountFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_finish(result: AsyncResult): boolean
-    vfunc_eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_eject_with_operation(flags: MountUnmountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_eject_with_operation_finish(result: AsyncResult): boolean
     vfunc_enumerate_identifiers(): string[]
     vfunc_get_activation_root(): File | null
@@ -1813,7 +1917,7 @@ export interface Volume {
     vfunc_get_symbolic_icon(): Icon
     vfunc_get_uuid(): string
     vfunc_mount_finish(result: AsyncResult): boolean
-    vfunc_mount_fn(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_mount_fn(flags: MountMountFlags, mount_operation: MountOperation | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_removed(): void
     vfunc_should_automount(): boolean
     /* Signals of Gio.Volume */
@@ -1834,9 +1938,9 @@ export interface AppInfoMonitor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1845,10 +1949,10 @@ export interface AppInfoMonitor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1892,9 +1996,9 @@ export interface AppLaunchContext {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1903,10 +2007,10 @@ export interface AppLaunchContext {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1994,9 +2098,9 @@ export interface Application {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2005,10 +2109,10 @@ export interface Application {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2091,9 +2195,9 @@ export interface ApplicationCommandLine {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2102,10 +2206,10 @@ export interface ApplicationCommandLine {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2147,7 +2251,7 @@ export interface BufferedInputStream {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.BufferedInputStream */
     fill(count: number, cancellable: Cancellable | null): number
-    fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     fill_finish(result: AsyncResult): number
     get_available(): number
     get_buffer_size(): number
@@ -2162,31 +2266,31 @@ export interface BufferedInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2195,26 +2299,26 @@ export interface BufferedInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.BufferedInputStream */
     vfunc_fill(count: number, cancellable: Cancellable | null): number
-    vfunc_fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_fill_finish(result: AsyncResult): number
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2267,25 +2371,25 @@ export interface BufferedOutputStream {
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -2293,9 +2397,9 @@ export interface BufferedOutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2304,26 +2408,26 @@ export interface BufferedOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -2360,9 +2464,9 @@ export interface BytesIcon {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2371,10 +2475,10 @@ export interface BytesIcon {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2406,7 +2510,7 @@ export interface Cancellable {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.Cancellable */
     cancel(): void
-    connect(callback: GObject.Callback, data: object, data_destroy_func: GLib.DestroyNotify | null): number
+    connect(callback: GObject.Callback, data: object | null, data_destroy_func: GLib.DestroyNotify | null): number
     disconnect(handler_id: number): void
     get_fd(): number
     is_cancelled(): boolean
@@ -2421,9 +2525,9 @@ export interface Cancellable {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2432,10 +2536,10 @@ export interface Cancellable {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2482,9 +2586,9 @@ export interface CharsetConverter {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2493,10 +2597,10 @@ export interface CharsetConverter {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2543,31 +2647,31 @@ export interface ConverterInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2576,22 +2680,22 @@ export interface ConverterInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2635,25 +2739,25 @@ export interface ConverterOutputStream {
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -2661,9 +2765,9 @@ export interface ConverterOutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2672,26 +2776,26 @@ export interface ConverterOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -2728,9 +2832,9 @@ export interface Credentials {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2739,10 +2843,10 @@ export interface Credentials {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2775,9 +2879,9 @@ export interface DBusActionGroup {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2786,10 +2890,10 @@ export interface DBusActionGroup {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2825,9 +2929,9 @@ export interface DBusAuthObserver {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2836,10 +2940,10 @@ export interface DBusAuthObserver {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2882,39 +2986,39 @@ export interface DBusConnection {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.DBusConnection */
-    add_filter(filter_function: DBusMessageFilterFunction, user_data: object, user_data_free_func: GLib.DestroyNotify): number
-    call(bus_name: string | null, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant | null, reply_type: GLib.VariantType | null, flags: DBusCallFlags, timeout_msec: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    add_filter(filter_function: DBusMessageFilterFunction, user_data: object | null, user_data_free_func: GLib.DestroyNotify): number
+    call(bus_name: string | null, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant | null, reply_type: GLib.VariantType | null, flags: DBusCallFlags, timeout_msec: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     call_finish(res: AsyncResult): GLib.Variant
     call_sync(bus_name: string | null, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant | null, reply_type: GLib.VariantType | null, flags: DBusCallFlags, timeout_msec: number, cancellable: Cancellable | null): GLib.Variant
-    call_with_unix_fd_list(bus_name: string | null, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant | null, reply_type: GLib.VariantType | null, flags: DBusCallFlags, timeout_msec: number, fd_list: UnixFDList | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    call_with_unix_fd_list(bus_name: string | null, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant | null, reply_type: GLib.VariantType | null, flags: DBusCallFlags, timeout_msec: number, fd_list: UnixFDList | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     call_with_unix_fd_list_finish(res: AsyncResult): [ /* returnType */ GLib.Variant, /* out_fd_list */ UnixFDList | null ]
     call_with_unix_fd_list_sync(bus_name: string | null, object_path: string, interface_name: string, method_name: string, parameters: GLib.Variant | null, reply_type: GLib.VariantType | null, flags: DBusCallFlags, timeout_msec: number, fd_list: UnixFDList | null, cancellable: Cancellable | null): [ /* returnType */ GLib.Variant, /* out_fd_list */ UnixFDList | null ]
-    close(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(res: AsyncResult): boolean
     close_sync(cancellable: Cancellable | null): boolean
     emit_signal(destination_bus_name: string | null, object_path: string, interface_name: string, signal_name: string, parameters: GLib.Variant | null): boolean
     export_action_group(object_path: string, action_group: ActionGroup): number
     export_menu_model(object_path: string, menu: MenuModel): number
-    flush(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(res: AsyncResult): boolean
     flush_sync(cancellable: Cancellable | null): boolean
     get_capabilities(): DBusCapabilityFlags
     get_exit_on_close(): boolean
     get_guid(): string
     get_last_serial(): number
-    get_peer_credentials(): Credentials
+    get_peer_credentials(): Credentials | null
     get_stream(): IOStream
     get_unique_name(): string
     is_closed(): boolean
     register_object_with_closures(object_path: string, interface_info: DBusInterfaceInfo, method_call_closure: Function, get_property_closure: Function, set_property_closure: Function): number
-    register_subtree(object_path: string, vtable: DBusSubtreeVTable, flags: DBusSubtreeFlags, user_data: object, user_data_free_func: GLib.DestroyNotify): number
+    register_subtree(object_path: string, vtable: DBusSubtreeVTable, flags: DBusSubtreeFlags, user_data: object | null, user_data_free_func: GLib.DestroyNotify): number
     remove_filter(filter_id: number): void
     send_message(message: DBusMessage, flags: DBusSendMessageFlags): [ /* returnType */ boolean, /* out_serial */ number | null ]
-    send_message_with_reply(message: DBusMessage, flags: DBusSendMessageFlags, timeout_msec: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): /* out_serial */ number | null
+    send_message_with_reply(message: DBusMessage, flags: DBusSendMessageFlags, timeout_msec: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): /* out_serial */ number | null
     send_message_with_reply_finish(res: AsyncResult): DBusMessage
     send_message_with_reply_sync(message: DBusMessage, flags: DBusSendMessageFlags, timeout_msec: number, cancellable: Cancellable | null): [ /* returnType */ DBusMessage, /* out_serial */ number | null ]
     set_exit_on_close(exit_on_close: boolean): void
-    signal_subscribe(sender: string | null, interface_name: string | null, member: string | null, object_path: string | null, arg0: string | null, flags: DBusSignalFlags, callback: DBusSignalCallback, user_data: object, user_data_free_func: GLib.DestroyNotify | null): number
+    signal_subscribe(sender: string | null, interface_name: string | null, member: string | null, object_path: string | null, arg0: string | null, flags: DBusSignalFlags, callback: DBusSignalCallback, user_data: object | null, user_data_free_func: GLib.DestroyNotify | null): number
     signal_unsubscribe(subscription_id: number): void
     start_message_processing(): void
     unexport_action_group(export_id: number): void
@@ -2926,9 +3030,9 @@ export interface DBusConnection {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2937,10 +3041,10 @@ export interface DBusConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2970,8 +3074,8 @@ export declare class DBusConnection_Static {
     new_for_address_finish(res: AsyncResult): DBusConnection
     new_for_address_sync(address: string, flags: DBusConnectionFlags, observer: DBusAuthObserver | null, cancellable: Cancellable | null): DBusConnection
     new_sync(stream: IOStream, guid: string | null, flags: DBusConnectionFlags, observer: DBusAuthObserver | null, cancellable: Cancellable | null): DBusConnection
-    new(stream: IOStream, guid: string | null, flags: DBusConnectionFlags, observer: DBusAuthObserver | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
-    new_for_address(address: string, flags: DBusConnectionFlags, observer: DBusAuthObserver | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    new(stream: IOStream, guid: string | null, flags: DBusConnectionFlags, observer: DBusAuthObserver | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    new_for_address(address: string, flags: DBusConnectionFlags, observer: DBusAuthObserver | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
 }
 export declare var DBusConnection: DBusConnection_Static
 export interface DBusInterfaceSkeleton_ConstructProps extends GObject.Object_ConstructProps {
@@ -3001,9 +3105,9 @@ export interface DBusInterfaceSkeleton {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3012,10 +3116,10 @@ export interface DBusInterfaceSkeleton {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3064,9 +3168,9 @@ export interface DBusMenuModel {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3075,10 +3179,10 @@ export interface DBusMenuModel {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3167,9 +3271,9 @@ export interface DBusMessage {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3178,10 +3282,10 @@ export interface DBusMessage {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3234,9 +3338,9 @@ export interface DBusMethodInvocation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3245,10 +3349,10 @@ export interface DBusMethodInvocation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3294,9 +3398,9 @@ export interface DBusObjectManagerClient {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3305,10 +3409,10 @@ export interface DBusObjectManagerClient {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3337,10 +3441,10 @@ export interface DBusObjectManagerClient_Static {
 export declare class DBusObjectManagerClient_Static {
     new_finish(res: AsyncResult): DBusObjectManagerClient
     new_for_bus_finish(res: AsyncResult): DBusObjectManagerClient
-    new_for_bus_sync(bus_type: BusType, flags: DBusObjectManagerClientFlags, name: string, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null): DBusObjectManagerClient
-    new_sync(connection: DBusConnection, flags: DBusObjectManagerClientFlags, name: string | null, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null): DBusObjectManagerClient
-    new(connection: DBusConnection, flags: DBusObjectManagerClientFlags, name: string, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
-    new_for_bus(bus_type: BusType, flags: DBusObjectManagerClientFlags, name: string, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    new_for_bus_sync(bus_type: BusType, flags: DBusObjectManagerClientFlags, name: string, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object | null, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null): DBusObjectManagerClient
+    new_sync(connection: DBusConnection, flags: DBusObjectManagerClientFlags, name: string | null, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object | null, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null): DBusObjectManagerClient
+    new(connection: DBusConnection, flags: DBusObjectManagerClientFlags, name: string, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object | null, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    new_for_bus(bus_type: BusType, flags: DBusObjectManagerClientFlags, name: string, object_path: string, get_proxy_type_func: DBusProxyTypeFunc | null, get_proxy_type_user_data: object | null, get_proxy_type_destroy_notify: GLib.DestroyNotify | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
 }
 export declare var DBusObjectManagerClient: DBusObjectManagerClient_Static
 export interface DBusObjectManagerServer_ConstructProps extends GObject.Object_ConstructProps {
@@ -3365,9 +3469,9 @@ export interface DBusObjectManagerServer {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3376,10 +3480,10 @@ export interface DBusObjectManagerServer {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3419,9 +3523,9 @@ export interface DBusObjectProxy {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3430,10 +3534,10 @@ export interface DBusObjectProxy {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3476,9 +3580,9 @@ export interface DBusObjectSkeleton {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3487,10 +3591,10 @@ export interface DBusObjectSkeleton {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3537,10 +3641,10 @@ export interface DBusProxy {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.DBusProxy */
-    call(method_name: string, parameters: GLib.Variant | null, flags: DBusCallFlags, timeout_msec: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    call(method_name: string, parameters: GLib.Variant | null, flags: DBusCallFlags, timeout_msec: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     call_finish(res: AsyncResult): GLib.Variant
     call_sync(method_name: string, parameters: GLib.Variant | null, flags: DBusCallFlags, timeout_msec: number, cancellable: Cancellable | null): GLib.Variant
-    call_with_unix_fd_list(method_name: string, parameters: GLib.Variant | null, flags: DBusCallFlags, timeout_msec: number, fd_list: UnixFDList | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    call_with_unix_fd_list(method_name: string, parameters: GLib.Variant | null, flags: DBusCallFlags, timeout_msec: number, fd_list: UnixFDList | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     call_with_unix_fd_list_finish(res: AsyncResult): [ /* returnType */ GLib.Variant, /* out_fd_list */ UnixFDList | null ]
     call_with_unix_fd_list_sync(method_name: string, parameters: GLib.Variant | null, flags: DBusCallFlags, timeout_msec: number, fd_list: UnixFDList | null, cancellable: Cancellable | null): [ /* returnType */ GLib.Variant, /* out_fd_list */ UnixFDList | null ]
     get_cached_property(property_name: string): GLib.Variant
@@ -3561,9 +3665,9 @@ export interface DBusProxy {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3572,10 +3676,10 @@ export interface DBusProxy {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3608,8 +3712,8 @@ export declare class DBusProxy_Static {
     new_for_bus_finish(res: AsyncResult): DBusProxy
     new_for_bus_sync(bus_type: BusType, flags: DBusProxyFlags, info: DBusInterfaceInfo | null, name: string, object_path: string, interface_name: string, cancellable: Cancellable | null): DBusProxy
     new_sync(connection: DBusConnection, flags: DBusProxyFlags, info: DBusInterfaceInfo | null, name: string | null, object_path: string, interface_name: string, cancellable: Cancellable | null): DBusProxy
-    new(connection: DBusConnection, flags: DBusProxyFlags, info: DBusInterfaceInfo | null, name: string | null, object_path: string, interface_name: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
-    new_for_bus(bus_type: BusType, flags: DBusProxyFlags, info: DBusInterfaceInfo | null, name: string, object_path: string, interface_name: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    new(connection: DBusConnection, flags: DBusProxyFlags, info: DBusInterfaceInfo | null, name: string | null, object_path: string, interface_name: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
+    new_for_bus(bus_type: BusType, flags: DBusProxyFlags, info: DBusInterfaceInfo | null, name: string, object_path: string, interface_name: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
 }
 export declare var DBusProxy: DBusProxy_Static
 export interface DBusServer_ConstructProps extends GObject.Object_ConstructProps {
@@ -3636,9 +3740,9 @@ export interface DBusServer {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3647,10 +3751,10 @@ export interface DBusServer {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3705,7 +3809,7 @@ export interface DataInputStream {
     read_int32(cancellable: Cancellable | null): number
     read_int64(cancellable: Cancellable | null): number
     read_line(cancellable: Cancellable | null): [ /* returnType */ Gjs.byteArray.ByteArray | null, /* length */ number ]
-    read_line_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_line_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_line_finish(result: AsyncResult): [ /* returnType */ Gjs.byteArray.ByteArray | null, /* length */ number ]
     read_line_finish_utf8(result: AsyncResult): [ /* returnType */ string | null, /* length */ number ]
     read_line_utf8(cancellable: Cancellable | null): [ /* returnType */ string | null, /* length */ number ]
@@ -3713,16 +3817,16 @@ export interface DataInputStream {
     read_uint32(cancellable: Cancellable | null): number
     read_uint64(cancellable: Cancellable | null): number
     read_until(stop_chars: string, cancellable: Cancellable | null): [ /* returnType */ string, /* length */ number ]
-    read_until_async(stop_chars: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_until_async(stop_chars: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_until_finish(result: AsyncResult): [ /* returnType */ string, /* length */ number ]
     read_upto(stop_chars: string, stop_chars_len: number, cancellable: Cancellable | null): [ /* returnType */ string, /* length */ number ]
-    read_upto_async(stop_chars: string, stop_chars_len: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_upto_async(stop_chars: string, stop_chars_len: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_upto_finish(result: AsyncResult): [ /* returnType */ string, /* length */ number ]
     set_byte_order(order: DataStreamByteOrder): void
     set_newline_type(type: DataStreamNewlineType): void
     /* Methods of Gio.BufferedInputStream */
     fill(count: number, cancellable: Cancellable | null): number
-    fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     fill_finish(result: AsyncResult): number
     get_available(): number
     get_buffer_size(): number
@@ -3736,31 +3840,31 @@ export interface DataInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3769,26 +3873,26 @@ export interface DataInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.BufferedInputStream */
     vfunc_fill(count: number, cancellable: Cancellable | null): number
-    vfunc_fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_fill_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_fill_finish(result: AsyncResult): number
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -3845,25 +3949,25 @@ export interface DataOutputStream {
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -3871,9 +3975,9 @@ export interface DataOutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3882,26 +3986,26 @@ export interface DataOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -3950,9 +4054,9 @@ export interface DesktopAppInfo {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3961,10 +4065,10 @@ export interface DesktopAppInfo {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4008,9 +4112,9 @@ export interface Emblem {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4019,10 +4123,10 @@ export interface Emblem {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4065,9 +4169,9 @@ export interface EmblemedIcon {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4076,10 +4180,10 @@ export interface EmblemedIcon {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4113,7 +4217,7 @@ export interface FileEnumerator {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.FileEnumerator */
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_child(info: FileInfo): File
     get_container(): File
@@ -4121,7 +4225,7 @@ export interface FileEnumerator {
     is_closed(): boolean
     iterate(cancellable: Cancellable | null): [ /* returnType */ boolean, /* out_info */ FileInfo | null, /* out_child */ File | null ]
     next_file(cancellable: Cancellable | null): FileInfo | null
-    next_files_async(num_files: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    next_files_async(num_files: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     next_files_finish(result: AsyncResult): GLib.List
     set_pending(pending: boolean): void
     /* Methods of GObject.Object */
@@ -4129,9 +4233,9 @@ export interface FileEnumerator {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4140,19 +4244,19 @@ export interface FileEnumerator {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.FileEnumerator */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_next_file(cancellable: Cancellable | null): FileInfo | null
-    vfunc_next_files_async(num_files: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_next_files_async(num_files: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_next_files_finish(result: AsyncResult): GLib.List
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -4185,27 +4289,27 @@ export interface FileIOStream {
     /* Methods of Gio.FileIOStream */
     get_etag(): string
     query_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     query_info_finish(result: AsyncResult): FileInfo
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4214,10 +4318,10 @@ export interface FileIOStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4226,13 +4330,13 @@ export interface FileIOStream {
     vfunc_can_truncate(): boolean
     vfunc_get_etag(): string
     vfunc_query_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    vfunc_query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_query_info_finish(result: AsyncResult): FileInfo
     vfunc_seek(offset: number, type: GLib.SeekType, cancellable: Cancellable | null): boolean
     vfunc_tell(): number
     vfunc_truncate_fn(size: number, cancellable: Cancellable | null): boolean
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -4270,9 +4374,9 @@ export interface FileIcon {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4281,10 +4385,10 @@ export interface FileIcon {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4347,7 +4451,7 @@ export interface FileInfo {
     get_symlink_target(): string
     has_attribute(attribute: string): boolean
     has_namespace(name_space: string): boolean
-    list_attributes(name_space: string): string[] | null
+    list_attributes(name_space: string | null): string[] | null
     remove_attribute(attribute: string): void
     set_attribute(attribute: string, type: FileAttributeType, value_p: object): void
     set_attribute_boolean(attribute: string, attr_value: boolean): void
@@ -4380,9 +4484,9 @@ export interface FileInfo {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4391,10 +4495,10 @@ export interface FileInfo {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4427,36 +4531,36 @@ export interface FileInputStream {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.FileInputStream */
     query_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     query_info_finish(result: AsyncResult): FileInfo
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4465,29 +4569,29 @@ export interface FileInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.FileInputStream */
     vfunc_can_seek(): boolean
     vfunc_query_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    vfunc_query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_query_info_finish(result: AsyncResult): FileInfo
     vfunc_seek(offset: number, type: GLib.SeekType, cancellable: Cancellable | null): boolean
     vfunc_tell(): number
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -4526,9 +4630,9 @@ export interface FileMonitor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4537,10 +4641,10 @@ export interface FileMonitor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4578,30 +4682,30 @@ export interface FileOutputStream {
     /* Methods of Gio.FileOutputStream */
     get_etag(): string
     query_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     query_info_finish(result: AsyncResult): FileInfo
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -4609,9 +4713,9 @@ export interface FileOutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4620,10 +4724,10 @@ export interface FileOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4632,24 +4736,24 @@ export interface FileOutputStream {
     vfunc_can_truncate(): boolean
     vfunc_get_etag(): string
     vfunc_query_info(attributes: string, cancellable: Cancellable | null): FileInfo
-    vfunc_query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_query_info_async(attributes: string, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_query_info_finish(result: AsyncResult): FileInfo
     vfunc_seek(offset: number, type: GLib.SeekType, cancellable: Cancellable | null): boolean
     vfunc_tell(): number
     vfunc_truncate_fn(size: number, cancellable: Cancellable | null): boolean
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -4680,9 +4784,9 @@ export interface FilenameCompleter {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4691,10 +4795,10 @@ export interface FilenameCompleter {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4741,31 +4845,31 @@ export interface FilterInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4774,22 +4878,22 @@ export interface FilterInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -4827,25 +4931,25 @@ export interface FilterOutputStream {
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -4853,9 +4957,9 @@ export interface FilterOutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4864,26 +4968,26 @@ export interface FilterOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -4927,9 +5031,9 @@ export interface IOModule {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4938,10 +5042,10 @@ export interface IOModule {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4982,22 +5086,22 @@ export interface IOStream {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5006,15 +5110,15 @@ export interface IOStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -5081,9 +5185,9 @@ export interface InetAddress {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5092,10 +5196,10 @@ export interface InetAddress {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5158,9 +5262,9 @@ export interface InetAddressMask {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5169,10 +5273,10 @@ export interface InetAddressMask {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5222,15 +5326,15 @@ export interface InetSocketAddress {
     /* Methods of Gio.SocketAddress */
     get_family(): SocketFamily
     get_native_size(): number
-    to_native(dest: object, destlen: number): boolean
+    to_native(dest: object | null, destlen: number): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5239,17 +5343,17 @@ export interface InetSocketAddress {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.SocketAddress */
     vfunc_get_family(): SocketFamily
     vfunc_get_native_size(): number
-    vfunc_to_native(dest: object, destlen: number): boolean
+    vfunc_to_native(dest: object | null, destlen: number): boolean
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -5281,31 +5385,31 @@ export interface InputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5314,22 +5418,22 @@ export interface InputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -5357,19 +5461,19 @@ export interface ListStore {
     /* Methods of Gio.ListStore */
     append(item: GObject.Object): void
     insert(position: number, item: GObject.Object): void
-    insert_sorted(item: GObject.Object, compare_func: GLib.CompareDataFunc, user_data: object): number
+    insert_sorted(item: GObject.Object, compare_func: GLib.CompareDataFunc, user_data: object | null): number
     remove(position: number): void
     remove_all(): void
-    sort(compare_func: GLib.CompareDataFunc, user_data: object): void
+    sort(compare_func: GLib.CompareDataFunc, user_data: object | null): void
     splice(position: number, n_removals: number, additions: GObject.Object[]): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5378,10 +5482,10 @@ export interface ListStore {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5418,31 +5522,31 @@ export interface MemoryInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5451,22 +5555,22 @@ export interface MemoryInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -5502,33 +5606,33 @@ export interface MemoryOutputStream {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.MemoryOutputStream */
-    get_data(): object
+    get_data(): object | null
     get_data_size(): number
     get_size(): number
     steal_as_bytes(): Gjs.byteArray.ByteArray
-    steal_data(): object
+    steal_data(): object | null
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -5537,7 +5641,7 @@ export interface MemoryOutputStream {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5546,25 +5650,25 @@ export interface MemoryOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_qdata(quark: GLib.Quark): object
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -5622,9 +5726,9 @@ export interface Menu {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5633,10 +5737,10 @@ export interface Menu {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5688,9 +5792,9 @@ export interface MenuAttributeIter {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5699,10 +5803,10 @@ export interface MenuAttributeIter {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5745,9 +5849,9 @@ export interface MenuItem {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5756,10 +5860,10 @@ export interface MenuItem {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5803,9 +5907,9 @@ export interface MenuLinkIter {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5814,10 +5918,10 @@ export interface MenuLinkIter {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5860,9 +5964,9 @@ export interface MenuModel {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5871,10 +5975,10 @@ export interface MenuModel {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5945,9 +6049,9 @@ export interface MountOperation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5956,10 +6060,10 @@ export interface MountOperation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6020,9 +6124,9 @@ export interface NativeVolumeMonitor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6031,10 +6135,10 @@ export interface NativeVolumeMonitor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6105,9 +6209,9 @@ export interface NetworkAddress {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6116,10 +6220,10 @@ export interface NetworkAddress {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6169,9 +6273,9 @@ export interface NetworkService {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6180,10 +6284,10 @@ export interface NetworkService {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6227,9 +6331,9 @@ export interface Notification {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6238,10 +6342,10 @@ export interface Notification {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6274,25 +6378,25 @@ export interface OutputStream {
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -6300,9 +6404,9 @@ export interface OutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6311,26 +6415,26 @@ export interface OutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -6360,23 +6464,23 @@ export interface Permission {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.Permission */
     acquire(cancellable: Cancellable | null): boolean
-    acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     acquire_finish(result: AsyncResult): boolean
     get_allowed(): boolean
     get_can_acquire(): boolean
     get_can_release(): boolean
     impl_update(allowed: boolean, can_acquire: boolean, can_release: boolean): void
     release(cancellable: Cancellable | null): boolean
-    release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     release_finish(result: AsyncResult): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6385,19 +6489,19 @@ export interface Permission {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.Permission */
     vfunc_acquire(cancellable: Cancellable | null): boolean
-    vfunc_acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_acquire_finish(result: AsyncResult): boolean
     vfunc_release(cancellable: Cancellable | null): boolean
-    vfunc_release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_release_finish(result: AsyncResult): boolean
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -6437,9 +6541,9 @@ export interface PropertyAction {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6448,10 +6552,10 @@ export interface PropertyAction {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6514,15 +6618,15 @@ export interface ProxyAddress {
     /* Methods of Gio.SocketAddress */
     get_family(): SocketFamily
     get_native_size(): number
-    to_native(dest: object, destlen: number): boolean
+    to_native(dest: object | null, destlen: number): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6531,17 +6635,17 @@ export interface ProxyAddress {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.SocketAddress */
     vfunc_get_family(): SocketFamily
     vfunc_get_native_size(): number
-    vfunc_to_native(dest: object, destlen: number): boolean
+    vfunc_to_native(dest: object | null, destlen: number): boolean
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -6579,16 +6683,16 @@ export interface ProxyAddressEnumerator {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.SocketAddressEnumerator */
     next(cancellable: Cancellable | null): SocketAddress
-    next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     next_finish(result: AsyncResult): SocketAddress
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6597,16 +6701,16 @@ export interface ProxyAddressEnumerator {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.SocketAddressEnumerator */
     vfunc_next(cancellable: Cancellable | null): SocketAddress
-    vfunc_next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_next_finish(result: AsyncResult): SocketAddress
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -6635,16 +6739,16 @@ export interface Resolver {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.Resolver */
     lookup_by_address(address: InetAddress, cancellable: Cancellable | null): string
-    lookup_by_address_async(address: InetAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_by_address_async(address: InetAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_by_address_finish(result: AsyncResult): string
     lookup_by_name(hostname: string, cancellable: Cancellable | null): GLib.List
-    lookup_by_name_async(hostname: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_by_name_async(hostname: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_by_name_finish(result: AsyncResult): GLib.List
     lookup_records(rrname: string, record_type: ResolverRecordType, cancellable: Cancellable | null): GLib.List
-    lookup_records_async(rrname: string, record_type: ResolverRecordType, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_records_async(rrname: string, record_type: ResolverRecordType, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_records_finish(result: AsyncResult): GLib.List
     lookup_service(service: string, protocol: string, domain: string, cancellable: Cancellable | null): GLib.List
-    lookup_service_async(service: string, protocol: string, domain: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_service_async(service: string, protocol: string, domain: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_service_finish(result: AsyncResult): GLib.List
     set_default(): void
     /* Methods of GObject.Object */
@@ -6652,9 +6756,9 @@ export interface Resolver {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6663,24 +6767,24 @@ export interface Resolver {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.Resolver */
     vfunc_lookup_by_address(address: InetAddress, cancellable: Cancellable | null): string
-    vfunc_lookup_by_address_async(address: InetAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_by_address_async(address: InetAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_by_address_finish(result: AsyncResult): string
     vfunc_lookup_by_name(hostname: string, cancellable: Cancellable | null): GLib.List
-    vfunc_lookup_by_name_async(hostname: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_by_name_async(hostname: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_by_name_finish(result: AsyncResult): GLib.List
     vfunc_lookup_records(rrname: string, record_type: ResolverRecordType, cancellable: Cancellable | null): GLib.List
-    vfunc_lookup_records_async(rrname: string, record_type: ResolverRecordType, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_records_async(rrname: string, record_type: ResolverRecordType, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_records_finish(result: AsyncResult): GLib.List
-    vfunc_lookup_service_async(rrname: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_service_async(rrname: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_service_finish(result: AsyncResult): GLib.List
     vfunc_reload(): void
     /* Virtual methods of GObject.Object */
@@ -6705,6 +6809,7 @@ export declare class Resolver_Static {
 }
 export declare var Resolver: Resolver_Static
 export interface Settings_ConstructProps extends GObject.Object_ConstructProps {
+    backend?:SettingsBackend
     path?:string
     schema?:string
     schema_id?:string
@@ -6727,18 +6832,20 @@ export interface Settings {
     delay(): void
     get_boolean(key: string): boolean
     get_child(name: string): Settings
-    get_default_value(key: string): GLib.Variant
+    get_default_value(key: string): GLib.Variant | null
     get_double(key: string): number
     get_enum(key: string): number
     get_flags(key: string): number
     get_has_unapplied(): boolean
     get_int(key: string): number
-    get_mapped(key: string, mapping: SettingsGetMapping, user_data: object): object
+    get_int64(key: string): number
+    get_mapped(key: string, mapping: SettingsGetMapping, user_data: object | null): object | null
     get_range(key: string): GLib.Variant
     get_string(key: string): string
     get_strv(key: string): string[]
     get_uint(key: string): number
-    get_user_value(key: string): GLib.Variant
+    get_uint64(key: string): number
+    get_user_value(key: string): GLib.Variant | null
     get_value(key: string): GLib.Variant
     is_writable(name: string): boolean
     list_children(): string[]
@@ -6751,18 +6858,20 @@ export interface Settings {
     set_enum(key: string, value: number): boolean
     set_flags(key: string, value: number): boolean
     set_int(key: string, value: number): boolean
+    set_int64(key: string, value: number): boolean
     set_string(key: string, value: string): boolean
     set_strv(key: string, value: string[] | null): boolean
     set_uint(key: string, value: number): boolean
+    set_uint64(key: string, value: number): boolean
     set_value(key: string, value: GLib.Variant): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6771,10 +6880,10 @@ export interface Settings {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6817,6 +6926,73 @@ export declare class Settings_Static {
     unbind(object: GObject.Object, property: string): void
 }
 export declare var Settings: Settings_Static
+export interface SettingsBackend_ConstructProps extends GObject.Object_ConstructProps {
+}
+export interface SettingsBackend {
+    /* Fields of Gio.SettingsBackend */
+    parent_instance:GObject.Object
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Gio.SettingsBackend */
+    changed(key: string, origin_tag: object | null): void
+    changed_tree(tree: GLib.Tree, origin_tag: object | null): void
+    keys_changed(path: string, items: string[], origin_tag: object | null): void
+    path_changed(path: string, origin_tag: object | null): void
+    path_writable_changed(path: string): void
+    writable_changed(key: string): void
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of Gio.SettingsBackend */
+    vfunc_get_writable(key: string): boolean
+    vfunc_read(key: string, expected_type: GLib.VariantType, default_value: boolean): GLib.Variant
+    vfunc_read_user_value(key: string, expected_type: GLib.VariantType): GLib.Variant
+    vfunc_reset(key: string, origin_tag: object | null): void
+    vfunc_subscribe(name: string): void
+    vfunc_sync(): void
+    vfunc_unsubscribe(name: string): void
+    vfunc_write(key: string, value: GLib.Variant, origin_tag: object | null): boolean
+    vfunc_write_tree(tree: GLib.Tree, origin_tag: object | null): boolean
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: SettingsBackend, pspec: GObject.ParamSpec) => void))
+}
+export interface SettingsBackend_Static {
+    name: string
+    new (config?: SettingsBackend_ConstructProps): SettingsBackend
+}
+export declare class SettingsBackend_Static {
+    flatten_tree(tree: GLib.Tree): [ /* path */ string, /* keys */ string[], /* values */ GLib.Variant[] | null ]
+    get_default(): SettingsBackend
+}
+export declare var SettingsBackend: SettingsBackend_Static
 export interface SimpleAction_ConstructProps extends GObject.Object_ConstructProps {
     enabled?:boolean
     name?:string
@@ -6839,9 +7015,9 @@ export interface SimpleAction {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6850,10 +7026,10 @@ export interface SimpleAction {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6890,7 +7066,7 @@ export interface SimpleActionGroup {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.SimpleActionGroup */
-    add_entries(entries: ActionEntry[], user_data: object): void
+    add_entries(entries: ActionEntry[], user_data: object | null): void
     insert(action: Action): void
     lookup(action_name: string): Action
     remove(action_name: string): void
@@ -6899,9 +7075,9 @@ export interface SimpleActionGroup {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6910,10 +7086,10 @@ export interface SimpleActionGroup {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6957,9 +7133,9 @@ export interface SimpleAsyncResult {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6968,10 +7144,10 @@ export interface SimpleAsyncResult {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6991,8 +7167,8 @@ export interface SimpleAsyncResult_Static {
     new (config?: SimpleAsyncResult_ConstructProps): SimpleAsyncResult
 }
 export declare class SimpleAsyncResult_Static {
-    new(source_object: GObject.Object | null, callback: AsyncReadyCallback | null, user_data: object, source_tag: object): SimpleAsyncResult
-    new_from_error(source_object: GObject.Object | null, callback: AsyncReadyCallback | null, user_data: object, error: GLib.Error): SimpleAsyncResult
+    new(source_object: GObject.Object | null, callback: AsyncReadyCallback | null, user_data: object | null, source_tag: object | null): SimpleAsyncResult
+    new_from_error(source_object: GObject.Object | null, callback: AsyncReadyCallback | null, user_data: object | null, error: GLib.Error): SimpleAsyncResult
     is_valid(result: AsyncResult, source: GObject.Object | null, source_tag: object | null): boolean
 }
 export declare var SimpleAsyncResult: SimpleAsyncResult_Static
@@ -7013,22 +7189,22 @@ export interface SimpleIOStream {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7037,15 +7213,15 @@ export interface SimpleIOStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -7085,23 +7261,23 @@ export interface SimplePermission {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.Permission */
     acquire(cancellable: Cancellable | null): boolean
-    acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     acquire_finish(result: AsyncResult): boolean
     get_allowed(): boolean
     get_can_acquire(): boolean
     get_can_release(): boolean
     impl_update(allowed: boolean, can_acquire: boolean, can_release: boolean): void
     release(cancellable: Cancellable | null): boolean
-    release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     release_finish(result: AsyncResult): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7110,19 +7286,19 @@ export interface SimplePermission {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.Permission */
     vfunc_acquire(cancellable: Cancellable | null): boolean
-    vfunc_acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_acquire_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_acquire_finish(result: AsyncResult): boolean
     vfunc_release(cancellable: Cancellable | null): boolean
-    vfunc_release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_release_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_release_finish(result: AsyncResult): boolean
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -7167,9 +7343,9 @@ export interface SimpleProxyResolver {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7178,10 +7354,10 @@ export interface SimpleProxyResolver {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7271,8 +7447,8 @@ export interface Socket {
     listen(): boolean
     receive(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     receive_from(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ number, /* address */ SocketAddress | null ]
-    receive_message(vectors: InputVector[], messages: SocketControlMessage[] | null, flags: number, cancellable: Cancellable | null): [ /* returnType */ number, /* address */ SocketAddress | null ]
-    receive_messages(messages: InputMessage, num_messages: number, flags: number, cancellable: Cancellable | null): number
+    receive_message(vectors: InputVector[], flags: number, cancellable: Cancellable | null): [ /* returnType */ number, /* address */ SocketAddress | null, /* messages */ SocketControlMessage[] | null ]
+    receive_messages(messages: InputMessage[], flags: number, cancellable: Cancellable | null): number
     receive_with_blocking(buffer: Gjs.byteArray.ByteArray, blocking: boolean, cancellable: Cancellable | null): number
     send(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     send_message(address: SocketAddress | null, vectors: OutputVector[], messages: SocketControlMessage[] | null, flags: number, cancellable: Cancellable | null): number
@@ -7295,9 +7471,9 @@ export interface Socket {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7306,10 +7482,10 @@ export interface Socket {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7355,15 +7531,15 @@ export interface SocketAddress {
     /* Methods of Gio.SocketAddress */
     get_family(): SocketFamily
     get_native_size(): number
-    to_native(dest: object, destlen: number): boolean
+    to_native(dest: object | null, destlen: number): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7372,17 +7548,17 @@ export interface SocketAddress {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.SocketAddress */
     vfunc_get_family(): SocketFamily
     vfunc_get_native_size(): number
-    vfunc_to_native(dest: object, destlen: number): boolean
+    vfunc_to_native(dest: object | null, destlen: number): boolean
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -7412,16 +7588,16 @@ export interface SocketAddressEnumerator {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.SocketAddressEnumerator */
     next(cancellable: Cancellable | null): SocketAddress
-    next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     next_finish(result: AsyncResult): SocketAddress
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7430,16 +7606,16 @@ export interface SocketAddressEnumerator {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.SocketAddressEnumerator */
     vfunc_next(cancellable: Cancellable | null): SocketAddress
-    vfunc_next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_next_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_next_finish(result: AsyncResult): SocketAddress
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -7487,16 +7663,16 @@ export interface SocketClient {
     /* Methods of Gio.SocketClient */
     add_application_proxy(protocol: string): void
     connect(connectable: SocketConnectable, cancellable: Cancellable | null): SocketConnection
-    connect_async(connectable: SocketConnectable, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_async(connectable: SocketConnectable, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_finish(result: AsyncResult): SocketConnection
     connect_to_host(host_and_port: string, default_port: number, cancellable: Cancellable | null): SocketConnection
-    connect_to_host_async(host_and_port: string, default_port: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_to_host_async(host_and_port: string, default_port: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_to_host_finish(result: AsyncResult): SocketConnection
     connect_to_service(domain: string, service: string, cancellable: Cancellable | null): SocketConnection
-    connect_to_service_async(domain: string, service: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_to_service_async(domain: string, service: string, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_to_service_finish(result: AsyncResult): SocketConnection
     connect_to_uri(uri: string, default_port: number, cancellable: Cancellable | null): SocketConnection
-    connect_to_uri_async(uri: string, default_port: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_to_uri_async(uri: string, default_port: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_to_uri_finish(result: AsyncResult): SocketConnection
     get_enable_proxy(): boolean
     get_family(): SocketFamily
@@ -7521,9 +7697,9 @@ export interface SocketClient {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7532,10 +7708,10 @@ export interface SocketClient {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7588,7 +7764,7 @@ export interface SocketConnection {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.SocketConnection */
     connect(address: SocketAddress, cancellable: Cancellable | null): boolean
-    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_finish(result: AsyncResult): boolean
     get_local_address(): SocketAddress
     get_remote_address(): SocketAddress
@@ -7597,22 +7773,22 @@ export interface SocketConnection {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7621,15 +7797,15 @@ export interface SocketConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -7675,9 +7851,9 @@ export interface SocketControlMessage {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7686,10 +7862,10 @@ export interface SocketControlMessage {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7730,10 +7906,10 @@ export interface SocketListener {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.SocketListener */
     accept(cancellable: Cancellable | null): [ /* returnType */ SocketConnection, /* source_object */ GObject.Object | null ]
-    accept_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    accept_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     accept_finish(result: AsyncResult): [ /* returnType */ SocketConnection, /* source_object */ GObject.Object | null ]
     accept_socket(cancellable: Cancellable | null): [ /* returnType */ Socket, /* source_object */ GObject.Object | null ]
-    accept_socket_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    accept_socket_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     accept_socket_finish(result: AsyncResult): [ /* returnType */ Socket, /* source_object */ GObject.Object | null ]
     add_address(address: SocketAddress, type: SocketType, protocol: SocketProtocol, source_object: GObject.Object | null): [ /* returnType */ boolean, /* effective_address */ SocketAddress | null ]
     add_any_inet_port(source_object: GObject.Object | null): number
@@ -7746,9 +7922,9 @@ export interface SocketListener {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7757,10 +7933,10 @@ export interface SocketListener {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7809,10 +7985,10 @@ export interface SocketService {
     stop(): void
     /* Methods of Gio.SocketListener */
     accept(cancellable: Cancellable | null): [ /* returnType */ SocketConnection, /* source_object */ GObject.Object | null ]
-    accept_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    accept_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     accept_finish(result: AsyncResult): [ /* returnType */ SocketConnection, /* source_object */ GObject.Object | null ]
     accept_socket(cancellable: Cancellable | null): [ /* returnType */ Socket, /* source_object */ GObject.Object | null ]
-    accept_socket_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    accept_socket_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     accept_socket_finish(result: AsyncResult): [ /* returnType */ Socket, /* source_object */ GObject.Object | null ]
     add_address(address: SocketAddress, type: SocketType, protocol: SocketProtocol, source_object: GObject.Object | null): [ /* returnType */ boolean, /* effective_address */ SocketAddress | null ]
     add_any_inet_port(source_object: GObject.Object | null): number
@@ -7825,9 +8001,9 @@ export interface SocketService {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7836,10 +8012,10 @@ export interface SocketService {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7883,10 +8059,10 @@ export interface Subprocess {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.Subprocess */
     communicate(stdin_buf: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* stdout_buf */ Gjs.byteArray.ByteArray, /* stderr_buf */ Gjs.byteArray.ByteArray ]
-    communicate_async(stdin_buf: Gjs.byteArray.ByteArray, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    communicate_async(stdin_buf: Gjs.byteArray.ByteArray, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     communicate_finish(result: AsyncResult): [ /* returnType */ boolean, /* stdout_buf */ Gjs.byteArray.ByteArray, /* stderr_buf */ Gjs.byteArray.ByteArray ]
     communicate_utf8(stdin_buf: string | null, cancellable: Cancellable | null): [ /* returnType */ boolean, /* stdout_buf */ string, /* stderr_buf */ string ]
-    communicate_utf8_async(stdin_buf: string | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    communicate_utf8_async(stdin_buf: string | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     communicate_utf8_finish(result: AsyncResult): [ /* returnType */ boolean, /* stdout_buf */ string, /* stderr_buf */ string ]
     force_exit(): void
     get_exit_status(): number
@@ -7901,9 +8077,9 @@ export interface Subprocess {
     get_term_sig(): number
     send_signal(signal_num: number): void
     wait(cancellable: Cancellable | null): boolean
-    wait_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    wait_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     wait_check(cancellable: Cancellable | null): boolean
-    wait_check_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    wait_check_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     wait_check_finish(result: AsyncResult): boolean
     wait_finish(result: AsyncResult): boolean
     /* Methods of GObject.Object */
@@ -7911,9 +8087,9 @@ export interface Subprocess {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7922,10 +8098,10 @@ export interface Subprocess {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7957,9 +8133,9 @@ export interface SubprocessLauncher {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.SubprocessLauncher */
     getenv(variable: string): string
-    set_child_setup(child_setup: GLib.SpawnChildSetupFunc, user_data: object, destroy_notify: GLib.DestroyNotify): void
+    set_child_setup(child_setup: GLib.SpawnChildSetupFunc, user_data: object | null, destroy_notify: GLib.DestroyNotify): void
     set_cwd(cwd: string): void
-    set_environ(env: string): void
+    set_environ(env: string[]): void
     set_flags(flags: SubprocessFlags): void
     set_stderr_file_path(path: string): void
     set_stdin_file_path(path: string): void
@@ -7976,9 +8152,9 @@ export interface SubprocessLauncher {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7987,10 +8163,10 @@ export interface SubprocessLauncher {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8028,12 +8204,12 @@ export interface Task {
     get_priority(): number
     get_return_on_cancel(): boolean
     get_source_object(): GObject.Object
-    get_source_tag(): object
-    get_task_data(): object
+    get_source_tag(): object | null
+    get_task_data(): object | null
     had_error(): boolean
     propagate_boolean(): boolean
     propagate_int(): number
-    propagate_pointer(): object
+    propagate_pointer(): object | null
     return_boolean(result: boolean): void
     return_error(error: GLib.Error): void
     return_error_if_cancelled(): boolean
@@ -8042,16 +8218,16 @@ export interface Task {
     set_check_cancellable(check_cancellable: boolean): void
     set_priority(priority: number): void
     set_return_on_cancel(return_on_cancel: boolean): boolean
-    set_source_tag(source_tag: object): void
+    set_source_tag(source_tag: object | null): void
     set_task_data(task_data: object | null, task_data_destroy: GLib.DestroyNotify | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8060,10 +8236,10 @@ export interface Task {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8084,9 +8260,9 @@ export interface Task_Static {
     new (config?: Task_ConstructProps): Task
 }
 export declare class Task_Static {
-    new(source_object: GObject.Object | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, callback_data: object): Task
+    new(source_object: GObject.Object | null, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, callback_data: object | null): Task
     is_valid(result: AsyncResult, source_object: GObject.Object | null): boolean
-    report_error(source_object: GObject.Object | null, callback: AsyncReadyCallback | null, callback_data: object, source_tag: object, error: GLib.Error): void
+    report_error(source_object: GObject.Object | null, callback: AsyncReadyCallback | null, callback_data: object | null, source_tag: object | null, error: GLib.Error): void
 }
 export declare var Task: Task_Static
 export interface TcpConnection_ConstructProps extends SocketConnection_ConstructProps {
@@ -8112,7 +8288,7 @@ export interface TcpConnection {
     set_graceful_disconnect(graceful_disconnect: boolean): void
     /* Methods of Gio.SocketConnection */
     connect(address: SocketAddress, cancellable: Cancellable | null): boolean
-    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_finish(result: AsyncResult): boolean
     get_local_address(): SocketAddress
     get_remote_address(): SocketAddress
@@ -8121,22 +8297,22 @@ export interface TcpConnection {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8145,15 +8321,15 @@ export interface TcpConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -8205,7 +8381,7 @@ export interface TcpWrapperConnection {
     set_graceful_disconnect(graceful_disconnect: boolean): void
     /* Methods of Gio.SocketConnection */
     connect(address: SocketAddress, cancellable: Cancellable | null): boolean
-    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_finish(result: AsyncResult): boolean
     get_local_address(): SocketAddress
     get_remote_address(): SocketAddress
@@ -8214,22 +8390,22 @@ export interface TcpWrapperConnection {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8238,15 +8414,15 @@ export interface TcpWrapperConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -8284,7 +8460,7 @@ export interface TestDBus {
     /* Methods of Gio.TestDBus */
     add_service_dir(path: string): void
     down(): void
-    get_bus_address(): string
+    get_bus_address(): string | null
     get_flags(): TestDBusFlags
     stop(): void
     up(): void
@@ -8293,9 +8469,9 @@ export interface TestDBus {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8304,10 +8480,10 @@ export interface TestDBus {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8349,9 +8525,9 @@ export interface ThemedIcon {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8360,10 +8536,10 @@ export interface ThemedIcon {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8410,10 +8586,10 @@ export interface ThreadedSocketService {
     stop(): void
     /* Methods of Gio.SocketListener */
     accept(cancellable: Cancellable | null): [ /* returnType */ SocketConnection, /* source_object */ GObject.Object | null ]
-    accept_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    accept_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     accept_finish(result: AsyncResult): [ /* returnType */ SocketConnection, /* source_object */ GObject.Object | null ]
     accept_socket(cancellable: Cancellable | null): [ /* returnType */ Socket, /* source_object */ GObject.Object | null ]
-    accept_socket_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    accept_socket_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     accept_socket_finish(result: AsyncResult): [ /* returnType */ Socket, /* source_object */ GObject.Object | null ]
     add_address(address: SocketAddress, type: SocketType, protocol: SocketProtocol, source_object: GObject.Object | null): [ /* returnType */ boolean, /* effective_address */ SocketAddress | null ]
     add_any_inet_port(source_object: GObject.Object | null): number
@@ -8426,9 +8602,9 @@ export interface ThreadedSocketService {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8437,10 +8613,10 @@ export interface ThreadedSocketService {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8501,9 +8677,9 @@ export interface TlsCertificate {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8512,10 +8688,10 @@ export interface TlsCertificate {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8583,7 +8759,7 @@ export interface TlsConnection {
     get_require_close_notify(): boolean
     get_use_system_certdb(): boolean
     handshake(cancellable: Cancellable | null): boolean
-    handshake_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    handshake_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     handshake_finish(result: AsyncResult): boolean
     set_certificate(certificate: TlsCertificate): void
     set_database(database: TlsDatabase): void
@@ -8594,22 +8770,22 @@ export interface TlsConnection {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8618,20 +8794,20 @@ export interface TlsConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.TlsConnection */
     vfunc_accept_certificate(peer_cert: TlsCertificate, errors: TlsCertificateFlags): boolean
     vfunc_handshake(cancellable: Cancellable | null): boolean
-    vfunc_handshake_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_handshake_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_handshake_finish(result: AsyncResult): boolean
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -8675,26 +8851,26 @@ export interface TlsDatabase {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.TlsDatabase */
     create_certificate_handle(certificate: TlsCertificate): string | null
-    lookup_certificate_for_handle(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): TlsCertificate
-    lookup_certificate_for_handle_async(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_certificate_for_handle(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): TlsCertificate | null
+    lookup_certificate_for_handle_async(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_certificate_for_handle_finish(result: AsyncResult): TlsCertificate
     lookup_certificate_issuer(certificate: TlsCertificate, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): TlsCertificate
-    lookup_certificate_issuer_async(certificate: TlsCertificate, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_certificate_issuer_async(certificate: TlsCertificate, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_certificate_issuer_finish(result: AsyncResult): TlsCertificate
     lookup_certificates_issued_by(issuer_raw_dn: Gjs.byteArray.ByteArray, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): GLib.List
-    lookup_certificates_issued_by_async(issuer_raw_dn: Gjs.byteArray.ByteArray, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    lookup_certificates_issued_by_async(issuer_raw_dn: Gjs.byteArray.ByteArray, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     lookup_certificates_issued_by_finish(result: AsyncResult): GLib.List
     verify_chain(chain: TlsCertificate, purpose: string, identity: SocketConnectable | null, interaction: TlsInteraction | null, flags: TlsDatabaseVerifyFlags, cancellable: Cancellable | null): TlsCertificateFlags
-    verify_chain_async(chain: TlsCertificate, purpose: string, identity: SocketConnectable | null, interaction: TlsInteraction | null, flags: TlsDatabaseVerifyFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    verify_chain_async(chain: TlsCertificate, purpose: string, identity: SocketConnectable | null, interaction: TlsInteraction | null, flags: TlsDatabaseVerifyFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     verify_chain_finish(result: AsyncResult): TlsCertificateFlags
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8703,26 +8879,26 @@ export interface TlsDatabase {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.TlsDatabase */
     vfunc_create_certificate_handle(certificate: TlsCertificate): string | null
-    vfunc_lookup_certificate_for_handle(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): TlsCertificate
-    vfunc_lookup_certificate_for_handle_async(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_certificate_for_handle(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): TlsCertificate | null
+    vfunc_lookup_certificate_for_handle_async(handle: string, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_certificate_for_handle_finish(result: AsyncResult): TlsCertificate
     vfunc_lookup_certificate_issuer(certificate: TlsCertificate, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): TlsCertificate
-    vfunc_lookup_certificate_issuer_async(certificate: TlsCertificate, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_certificate_issuer_async(certificate: TlsCertificate, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_certificate_issuer_finish(result: AsyncResult): TlsCertificate
     vfunc_lookup_certificates_issued_by(issuer_raw_dn: Gjs.byteArray.ByteArray, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null): GLib.List
-    vfunc_lookup_certificates_issued_by_async(issuer_raw_dn: Gjs.byteArray.ByteArray, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_lookup_certificates_issued_by_async(issuer_raw_dn: Gjs.byteArray.ByteArray, interaction: TlsInteraction | null, flags: TlsDatabaseLookupFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_lookup_certificates_issued_by_finish(result: AsyncResult): GLib.List
     vfunc_verify_chain(chain: TlsCertificate, purpose: string, identity: SocketConnectable | null, interaction: TlsInteraction | null, flags: TlsDatabaseVerifyFlags, cancellable: Cancellable | null): TlsCertificateFlags
-    vfunc_verify_chain_async(chain: TlsCertificate, purpose: string, identity: SocketConnectable | null, interaction: TlsInteraction | null, flags: TlsDatabaseVerifyFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_verify_chain_async(chain: TlsCertificate, purpose: string, identity: SocketConnectable | null, interaction: TlsInteraction | null, flags: TlsDatabaseVerifyFlags, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_verify_chain_finish(result: AsyncResult): TlsCertificateFlags
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -8760,9 +8936,9 @@ export interface TlsInteraction {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8771,10 +8947,10 @@ export interface TlsInteraction {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8831,9 +9007,9 @@ export interface TlsPassword {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8842,10 +9018,10 @@ export interface TlsPassword {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8892,16 +9068,16 @@ export interface UnixConnection {
     g_type_instance:GObject.TypeInstance
     /* Methods of Gio.UnixConnection */
     receive_credentials(cancellable: Cancellable | null): Credentials
-    receive_credentials_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    receive_credentials_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     receive_credentials_finish(result: AsyncResult): Credentials
     receive_fd(cancellable: Cancellable | null): number
     send_credentials(cancellable: Cancellable | null): boolean
-    send_credentials_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    send_credentials_async(cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     send_credentials_finish(result: AsyncResult): boolean
     send_fd(fd: number, cancellable: Cancellable | null): boolean
     /* Methods of Gio.SocketConnection */
     connect(address: SocketAddress, cancellable: Cancellable | null): boolean
-    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    connect_async(address: SocketAddress, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     connect_finish(result: AsyncResult): boolean
     get_local_address(): SocketAddress
     get_remote_address(): SocketAddress
@@ -8910,22 +9086,22 @@ export interface UnixConnection {
     /* Methods of Gio.IOStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     get_input_stream(): InputStream
     get_output_stream(): OutputStream
     has_pending(): boolean
     is_closed(): boolean
     set_pending(): boolean
-    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(stream2: IOStream, flags: IOStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8934,15 +9110,15 @@ export interface UnixConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.IOStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_get_input_stream(): InputStream
@@ -8989,9 +9165,9 @@ export interface UnixCredentialsMessage {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9000,10 +9176,10 @@ export interface UnixCredentialsMessage {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9052,9 +9228,9 @@ export interface UnixFDList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9063,10 +9239,10 @@ export interface UnixFDList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9115,9 +9291,9 @@ export interface UnixFDMessage {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9126,10 +9302,10 @@ export interface UnixFDMessage {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9177,31 +9353,31 @@ export interface UnixInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9210,22 +9386,22 @@ export interface UnixInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Cancellable | null): number
     vfunc_skip(count: number, cancellable: Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -9259,9 +9435,9 @@ export interface UnixMountMonitor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9270,10 +9446,10 @@ export interface UnixMountMonitor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9319,25 +9495,25 @@ export interface UnixOutputStream {
     /* Methods of Gio.OutputStream */
     clear_pending(): void
     close(cancellable: Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: AsyncResult): boolean
     flush(cancellable: Cancellable | null): boolean
-    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     flush_finish(result: AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     is_closing(): boolean
     set_pending(): boolean
     splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     splice_finish(result: AsyncResult): number
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
     write_all(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_all_finish(result: AsyncResult): [ /* returnType */ boolean, /* bytes_written */ number ]
-    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes(bytes: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
-    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    write_bytes_async(bytes: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     write_bytes_finish(result: AsyncResult): number
     write_finish(result: AsyncResult): number
     /* Methods of GObject.Object */
@@ -9345,9 +9521,9 @@ export interface UnixOutputStream {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9356,26 +9532,26 @@ export interface UnixOutputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.OutputStream */
-    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: AsyncResult): boolean
     vfunc_close_fn(cancellable: Cancellable | null): boolean
     vfunc_flush(cancellable: Cancellable | null): boolean
-    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_flush_async(io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_flush_finish(result: AsyncResult): boolean
     vfunc_splice(source: InputStream, flags: OutputStreamSpliceFlags, cancellable: Cancellable | null): number
-    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_splice_async(source: InputStream, flags: OutputStreamSpliceFlags, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_splice_finish(result: AsyncResult): number
-    vfunc_write_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object): void
+    vfunc_write_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Cancellable | null, callback: AsyncReadyCallback | null, user_data: object | null): void
     vfunc_write_finish(result: AsyncResult): number
-    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray, cancellable: Cancellable | null): number
+    vfunc_write_fn(buffer: Gjs.byteArray.ByteArray | null, cancellable: Cancellable | null): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -9419,15 +9595,15 @@ export interface UnixSocketAddress {
     /* Methods of Gio.SocketAddress */
     get_family(): SocketFamily
     get_native_size(): number
-    to_native(dest: object, destlen: number): boolean
+    to_native(dest: object | null, destlen: number): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9436,17 +9612,17 @@ export interface UnixSocketAddress {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.SocketAddress */
     vfunc_get_family(): SocketFamily
     vfunc_get_native_size(): number
-    vfunc_to_native(dest: object, destlen: number): boolean
+    vfunc_to_native(dest: object | null, destlen: number): boolean
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
     vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
@@ -9483,14 +9659,16 @@ export interface Vfs {
     get_supported_uri_schemes(): string[]
     is_active(): boolean
     parse_name(parse_name: string): File
+    register_uri_scheme(scheme: string, uri_func: VfsFileLookupFunc | null, uri_data: object | null, uri_destroy: GLib.DestroyNotify | null, parse_name_func: VfsFileLookupFunc | null, parse_name_data: object | null, parse_name_destroy: GLib.DestroyNotify | null): boolean
+    unregister_uri_scheme(scheme: string): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9499,10 +9677,10 @@ export interface Vfs {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9512,7 +9690,7 @@ export interface Vfs {
     vfunc_get_file_for_uri(uri: string): File
     vfunc_get_supported_uri_schemes(): string[]
     vfunc_is_active(): boolean
-    vfunc_local_file_add_info(filename: string, device: number, attribute_matcher: FileAttributeMatcher, info: FileInfo, cancellable: Cancellable | null, extra_data: object, free_extra_data: GLib.DestroyNotify): void
+    vfunc_local_file_add_info(filename: string, device: number, attribute_matcher: FileAttributeMatcher, info: FileInfo, cancellable: Cancellable | null, extra_data: object | null, free_extra_data: GLib.DestroyNotify): void
     vfunc_local_file_moved(source: string, dest: string): void
     vfunc_local_file_removed(filename: string): void
     vfunc_local_file_set_attributes(filename: string, info: FileInfo, flags: FileQueryInfoFlags, cancellable: Cancellable | null): boolean
@@ -9555,9 +9733,9 @@ export interface VolumeMonitor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9566,10 +9744,10 @@ export interface VolumeMonitor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9642,9 +9820,9 @@ export interface ZlibCompressor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9653,10 +9831,10 @@ export interface ZlibCompressor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9695,9 +9873,9 @@ export interface ZlibDecompressor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9706,10 +9884,10 @@ export interface ZlibDecompressor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -10107,8 +10285,8 @@ export interface IOModuleScope_Static {
 export declare var IOModuleScope: IOModuleScope_Static
 export interface IOSchedulerJob {
     /* Methods of Gio.IOSchedulerJob */
-    send_to_mainloop(func: GLib.SourceFunc, user_data: object, notify: GLib.DestroyNotify | null): boolean
-    send_to_mainloop_async(func: GLib.SourceFunc, user_data: object, notify: GLib.DestroyNotify | null): void
+    send_to_mainloop(func: GLib.SourceFunc, user_data: object | null, notify: GLib.DestroyNotify | null): boolean
+    send_to_mainloop_async(func: GLib.SourceFunc, user_data: object | null, notify: GLib.DestroyNotify | null): void
 }
 export interface IOSchedulerJob_Static {
     name: string
@@ -10298,12 +10476,12 @@ export declare class Resource_Static {
     load(filename: string): Resource
 }
 export declare var Resource: Resource_Static
-export interface SettingsBackend {
+export interface SettingsBackendPrivate {
 }
-export interface SettingsBackend_Static {
+export interface SettingsBackendPrivate_Static {
     name: string
 }
-export declare var SettingsBackend: SettingsBackend_Static
+export declare var SettingsBackendPrivate: SettingsBackendPrivate_Static
 export interface SettingsPrivate {
 }
 export interface SettingsPrivate_Static {
@@ -10548,141 +10726,3 @@ export interface UnixSocketAddressPrivate_Static {
     name: string
 }
 export declare var UnixSocketAddressPrivate: UnixSocketAddressPrivate_Static
-type ActionMap_autoptr = object
-type Action_autoptr = object
-type AppInfoMonitor_autoptr = object
-type AppInfo_autoptr = object
-type AppLaunchContext_autoptr = object
-type ApplicationCommandLine_autoptr = object
-type Application_autoptr = object
-type AsyncInitable_autoptr = object
-type AsyncResult_autoptr = object
-type BufferedInputStream_autoptr = object
-type BufferedOutputStream_autoptr = object
-type BytesIcon_autoptr = object
-type Cancellable_autoptr = object
-type CharsetConverter_autoptr = object
-type ConverterInputStream_autoptr = object
-type ConverterOutputStream_autoptr = object
-type Converter_autoptr = object
-type Credentials_autoptr = object
-type DBusActionGroup_autoptr = object
-type DBusAuthObserver_autoptr = object
-type DBusConnection_autoptr = object
-type DBusInterfaceSkeleton_autoptr = object
-type DBusInterface_autoptr = object
-type DBusMenuModel_autoptr = object
-type DBusMessage_autoptr = object
-type DBusMethodInvocation_autoptr = object
-type DBusNodeInfo_autoptr = object
-type DBusObjectManagerClient_autoptr = object
-type DBusObjectManagerServer_autoptr = object
-type DBusObjectManager_autoptr = object
-type DBusObjectProxy_autoptr = object
-type DBusObjectSkeleton_autoptr = object
-type DBusObject_autoptr = object
-type DBusProxy_autoptr = object
-type DBusServer_autoptr = object
-type DataInputStream_autoptr = object
-type DataOutputStream_autoptr = object
-type DatagramBased_autoptr = object
-type DesktopAppInfo_autoptr = object
-type Drive_autoptr = object
-type Emblem_autoptr = object
-type EmblemedIcon_autoptr = object
-type FileDescriptorBased_autoptr = object
-type FileEnumerator_autoptr = object
-type FileIOStream_autoptr = object
-type FileIcon_autoptr = object
-type FileInfo_autoptr = object
-type FileInputStream_autoptr = object
-type FileMonitor_autoptr = object
-type FileOutputStream_autoptr = object
-type File_autoptr = object
-type FilenameCompleter_autoptr = object
-type FilterInputStream_autoptr = object
-type FilterOutputStream_autoptr = object
-type IOModule_autoptr = object
-type IOStream_autoptr = object
-type Icon_autoptr = object
-type InetAddressMask_autoptr = object
-type InetAddress_autoptr = object
-type InetSocketAddress_autoptr = object
-type Initable_autoptr = object
-type InputStream_autoptr = object
-type ListModel_autoptr = object
-type ListStore_autoptr = object
-type LoadableIcon_autoptr = object
-type MemoryInputStream_autoptr = object
-type MemoryOutputStream_autoptr = object
-type MenuAttributeIter_autoptr = object
-type MenuItem_autoptr = object
-type MenuLinkIter_autoptr = object
-type MenuModel_autoptr = object
-type Menu_autoptr = object
-type MountOperation_autoptr = object
-type Mount_autoptr = object
-type NativeVolumeMonitor_autoptr = object
-type NetworkAddress_autoptr = object
-type NetworkMonitor_autoptr = object
-type NetworkService_autoptr = object
-type Notification_autoptr = object
-type OutputStream_autoptr = object
-type Permission_autoptr = object
-type PollableInputStream_autoptr = object
-type PollableOutputStream_autoptr = object
-type PropertyAction_autoptr = object
-type ProxyAddressEnumerator_autoptr = object
-type ProxyAddress_autoptr = object
-type ProxyResolver_autoptr = object
-type Proxy_autoptr = object
-type RemoteActionGroup_autoptr = object
-type Resolver_autoptr = object
-type Seekable_autoptr = object
-type SettingsBackend_autoptr = object
-type SettingsSchema_autoptr = object
-type Settings_autoptr = object
-type SimpleActionGroup_autoptr = object
-type SimpleAction_autoptr = object
-type SimpleAsyncResult_autoptr = object
-type SimplePermission_autoptr = object
-type SimpleProxyResolver_autoptr = object
-type SocketAddressEnumerator_autoptr = object
-type SocketAddress_autoptr = object
-type SocketClient_autoptr = object
-type SocketConnectable_autoptr = object
-type SocketConnection_autoptr = object
-type SocketControlMessage_autoptr = object
-type SocketListener_autoptr = object
-type SocketService_autoptr = object
-type Socket_autoptr = object
-type SubprocessLauncher_autoptr = object
-type Subprocess_autoptr = object
-type Task_autoptr = object
-type TcpConnection_autoptr = object
-type TcpWrapperConnection_autoptr = object
-type TestDBus_autoptr = object
-type ThemedIcon_autoptr = object
-type ThreadedSocketService_autoptr = object
-type TlsBackend_autoptr = object
-type TlsCertificate_autoptr = object
-type TlsClientConnection_autoptr = object
-type TlsConnection_autoptr = object
-type TlsDatabase_autoptr = object
-type TlsFileDatabase_autoptr = object
-type TlsInteraction_autoptr = object
-type TlsPassword_autoptr = object
-type TlsServerConnection_autoptr = object
-type UnixConnection_autoptr = object
-type UnixCredentialsMessage_autoptr = object
-type UnixFDList_autoptr = object
-type UnixFDMessage_autoptr = object
-type UnixInputStream_autoptr = object
-type UnixMountMonitor_autoptr = object
-type UnixOutputStream_autoptr = object
-type UnixSocketAddress_autoptr = object
-type Vfs_autoptr = object
-type VolumeMonitor_autoptr = object
-type Volume_autoptr = object
-type ZlibCompressor_autoptr = object
-type ZlibDecompressor_autoptr = object

--- a/out/GtkSource.d.ts
+++ b/out/GtkSource.d.ts
@@ -100,6 +100,21 @@ export enum SortFlags {
     REVERSE_ORDER,
     REMOVE_DUPLICATES,
 }
+export enum SpaceLocationFlags {
+    NONE,
+    LEADING,
+    INSIDE_TEXT,
+    TRAILING,
+    ALL,
+}
+export enum SpaceTypeFlags {
+    NONE,
+    SPACE,
+    TAB,
+    NEWLINE,
+    NBSP,
+    ALL,
+}
 export function completion_error_quark(): GLib.Quark
 export function encoding_get_all(): GLib.SList
 export function encoding_get_current(): Encoding
@@ -314,7 +329,7 @@ export interface Buffer {
     get_iter_at_mark(mark: Gtk.TextMark): /* iter */ Gtk.TextIter
     get_iter_at_offset(char_offset: number): /* iter */ Gtk.TextIter
     get_line_count(): number
-    get_mark(name: string): Gtk.TextMark
+    get_mark(name: string): Gtk.TextMark | null
     get_modified(): boolean
     get_paste_target_list(): Gtk.TargetList
     get_selection_bound(): Gtk.TextMark
@@ -337,9 +352,9 @@ export interface Buffer {
     move_mark_by_name(name: string, where: Gtk.TextIter): void
     paste_clipboard(clipboard: Gtk.Clipboard, override_location: Gtk.TextIter | null, default_editable: boolean): void
     place_cursor(where: Gtk.TextIter): void
-    register_deserialize_format(mime_type: string, function_: Gtk.TextBufferDeserializeFunc, user_data: object, user_data_destroy: GLib.DestroyNotify): Gdk.Atom
+    register_deserialize_format(mime_type: string, function_: Gtk.TextBufferDeserializeFunc, user_data: object | null, user_data_destroy: GLib.DestroyNotify): Gdk.Atom
     register_deserialize_tagset(tagset_name: string | null): Gdk.Atom
-    register_serialize_format(mime_type: string, function_: Gtk.TextBufferSerializeFunc, user_data: object, user_data_destroy: GLib.DestroyNotify): Gdk.Atom
+    register_serialize_format(mime_type: string, function_: Gtk.TextBufferSerializeFunc, user_data: object | null, user_data_destroy: GLib.DestroyNotify): Gdk.Atom
     register_serialize_tagset(tagset_name: string | null): Gdk.Atom
     remove_all_tags(start: Gtk.TextIter, end: Gtk.TextIter): void
     remove_selection_clipboard(clipboard: Gtk.Clipboard): void
@@ -356,9 +371,9 @@ export interface Buffer {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -367,10 +382,10 @@ export interface Buffer {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -489,9 +504,9 @@ export interface Completion {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -500,10 +515,10 @@ export interface Completion {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -570,9 +585,9 @@ export interface CompletionContext {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -581,10 +596,10 @@ export interface CompletionContext {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -658,6 +673,7 @@ export interface CompletionInfo {
     double_buffered:boolean
     events:Gdk.EventMask
     expand:boolean
+    focus_on_click:boolean
     halign:Gtk.Align
     has_default:boolean
     has_focus:boolean
@@ -719,14 +735,14 @@ export interface CompletionInfo {
     fullscreen(): void
     fullscreen_on_monitor(screen: Gdk.Screen, monitor: number): void
     get_accept_focus(): boolean
-    get_application(): Gtk.Application
-    get_attached_to(): Gtk.Widget
+    get_application(): Gtk.Application | null
+    get_attached_to(): Gtk.Widget | null
     get_decorated(): boolean
     get_default_size(): [ /* width */ number | null, /* height */ number | null ]
-    get_default_widget(): Gtk.Widget
+    get_default_widget(): Gtk.Widget | null
     get_deletable(): boolean
     get_destroy_with_parent(): boolean
-    get_focus(): Gtk.Widget
+    get_focus(): Gtk.Widget | null
     get_focus_on_map(): boolean
     get_focus_visible(): boolean
     get_gravity(): Gdk.Gravity
@@ -735,7 +751,7 @@ export interface CompletionInfo {
     get_hide_titlebar_when_maximized(): boolean
     get_icon(): GdkPixbuf.Pixbuf
     get_icon_list(): GLib.List
-    get_icon_name(): string
+    get_icon_name(): string | null
     get_mnemonic_modifier(): Gdk.ModifierType
     get_mnemonics_visible(): boolean
     get_modal(): boolean
@@ -743,14 +759,14 @@ export interface CompletionInfo {
     get_position(): [ /* root_x */ number | null, /* root_y */ number | null ]
     get_resizable(): boolean
     get_resize_grip_area(): [ /* returnType */ boolean, /* rect */ Gdk.Rectangle ]
-    get_role(): string
+    get_role(): string | null
     get_screen(): Gdk.Screen
     get_size(): [ /* width */ number | null, /* height */ number | null ]
     get_skip_pager_hint(): boolean
     get_skip_taskbar_hint(): boolean
-    get_title(): string
-    get_titlebar(): Gtk.Widget
-    get_transient_for(): Gtk.Window
+    get_title(): string | null
+    get_titlebar(): Gtk.Widget | null
+    get_transient_for(): Gtk.Window | null
     get_type_hint(): Gdk.WindowTypeHint
     get_urgency_hint(): boolean
     get_window_type(): Gtk.WindowType
@@ -814,7 +830,7 @@ export interface CompletionInfo {
     unmaximize(): void
     unstick(): void
     /* Methods of Gtk.Bin */
-    get_child(): Gtk.Widget
+    get_child(): Gtk.Widget | null
     /* Methods of Gtk.Container */
     add(widget: Gtk.Widget): void
     check_resize(): void
@@ -822,14 +838,14 @@ export interface CompletionInfo {
     child_notify_by_pspec(child: Gtk.Widget, pspec: GObject.ParamSpec): void
     child_set_property(child: Gtk.Widget, property_name: string, value: any): void
     child_type(): number
-    forall(callback: Gtk.Callback, callback_data: object): void
-    foreach(callback: Gtk.Callback, callback_data: object): void
+    forall(callback: Gtk.Callback, callback_data: object | null): void
+    foreach(callback: Gtk.Callback, callback_data: object | null): void
     get_border_width(): number
     get_children(): GLib.List
     get_focus_chain(): [ /* returnType */ boolean, /* focusable_widgets */ GLib.List ]
-    get_focus_child(): Gtk.Widget
-    get_focus_hadjustment(): Gtk.Adjustment
-    get_focus_vadjustment(): Gtk.Adjustment
+    get_focus_child(): Gtk.Widget | null
+    get_focus_hadjustment(): Gtk.Adjustment | null
+    get_focus_vadjustment(): Gtk.Adjustment | null
     get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     get_resize_mode(): Gtk.ResizeMode
     propagate_draw(child: Gtk.Widget, cr: cairo.Context): void
@@ -849,7 +865,7 @@ export interface CompletionInfo {
     add_device_events(device: Gdk.Device, events: Gdk.EventMask): void
     add_events(events: number): void
     add_mnemonic_label(label: Gtk.Widget): void
-    add_tick_callback(callback: Gtk.TickCallback, user_data: object, notify: GLib.DestroyNotify): number
+    add_tick_callback(callback: Gtk.TickCallback, user_data: object | null, notify: GLib.DestroyNotify): number
     can_activate_accel(signal_id: number): boolean
     child_focus(direction: Gtk.DirectionType): boolean
     child_notify(child_property: string): void
@@ -867,7 +883,7 @@ export interface CompletionInfo {
     drag_dest_add_text_targets(): void
     drag_dest_add_uri_targets(): void
     drag_dest_find_target(context: Gdk.DragContext, target_list: Gtk.TargetList | null): Gdk.Atom
-    drag_dest_get_target_list(): Gtk.TargetList
+    drag_dest_get_target_list(): Gtk.TargetList | null
     drag_dest_get_track_motion(): boolean
     drag_dest_set(flags: Gtk.DestDefaults, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_dest_set_proxy(proxy_window: Gdk.Window, protocol: Gdk.DragProtocol, use_coordinates: boolean): void
@@ -879,7 +895,7 @@ export interface CompletionInfo {
     drag_source_add_image_targets(): void
     drag_source_add_text_targets(): void
     drag_source_add_uri_targets(): void
-    drag_source_get_target_list(): Gtk.TargetList
+    drag_source_get_target_list(): Gtk.TargetList | null
     drag_source_set(start_button_mask: Gdk.ModifierType, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_source_set_icon_gicon(icon: Gio.Icon): void
     drag_source_set_icon_name(icon_name: string): void
@@ -897,6 +913,7 @@ export interface CompletionInfo {
     get_action_group(prefix: string): Gio.ActionGroup | null
     get_allocated_baseline(): number
     get_allocated_height(): number
+    get_allocated_size(): [ /* allocation */ Gtk.Allocation, /* baseline */ number | null ]
     get_allocated_width(): number
     get_allocation(): /* allocation */ Gtk.Allocation
     get_ancestor(widget_type: number): Gtk.Widget | null
@@ -914,9 +931,10 @@ export interface CompletionInfo {
     get_display(): Gdk.Display
     get_double_buffered(): boolean
     get_events(): number
+    get_focus_on_click(): boolean
     get_font_map(): Pango.FontMap | null
     get_font_options(): cairo.FontOptions | null
-    get_frame_clock(): Gdk.FrameClock
+    get_frame_clock(): Gdk.FrameClock | null
     get_halign(): Gtk.Align
     get_has_tooltip(): boolean
     get_has_window(): boolean
@@ -935,7 +953,7 @@ export interface CompletionInfo {
     get_no_show_all(): boolean
     get_pango_context(): Pango.Context
     get_parent(): Gtk.Widget | null
-    get_parent_window(): Gdk.Window
+    get_parent_window(): Gdk.Window | null
     get_path(): Gtk.WidgetPath
     get_pointer(): [ /* x */ number | null, /* y */ number | null ]
     get_preferred_height(): [ /* minimum_height */ number | null, /* natural_height */ number | null ]
@@ -969,7 +987,7 @@ export interface CompletionInfo {
     get_vexpand_set(): boolean
     get_visible(): boolean
     get_visual(): Gdk.Visual
-    get_window(): Gdk.Window
+    get_window(): Gdk.Window | null
     grab_add(): void
     grab_default(): void
     grab_focus(): void
@@ -984,7 +1002,7 @@ export interface CompletionInfo {
     init_template(): void
     input_shape_combine_region(region: cairo.Region | null): void
     insert_action_group(name: string, group: Gio.ActionGroup | null): void
-    intersect(area: Gdk.Rectangle, intersection: Gdk.Rectangle | null): boolean
+    intersect(area: Gdk.Rectangle): [ /* returnType */ boolean, /* intersection */ Gdk.Rectangle | null ]
     is_ancestor(ancestor: Gtk.Widget): boolean
     is_composited(): boolean
     is_drawable(): boolean
@@ -1009,6 +1027,7 @@ export interface CompletionInfo {
     override_font(font_desc: Pango.FontDescription | null): void
     override_symbolic_color(name: string, color: Gdk.RGBA | null): void
     path(): [ /* path_length */ number | null, /* path */ string | null, /* path_reversed */ string | null ]
+    queue_allocate(): void
     queue_compute_expand(): void
     queue_draw(): void
     queue_draw_area(x: number, y: number, width: number, height: number): void
@@ -1021,7 +1040,7 @@ export interface CompletionInfo {
     remove_accelerator(accel_group: Gtk.AccelGroup, accel_key: number, accel_mods: Gdk.ModifierType): boolean
     remove_mnemonic_label(label: Gtk.Widget): void
     remove_tick_callback(id: number): void
-    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf
+    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf | null
     render_icon_pixbuf(stock_id: string, size: number): GdkPixbuf.Pixbuf | null
     reparent(new_parent: Gtk.Widget): void
     reset_rc_styles(): void
@@ -1041,6 +1060,7 @@ export interface CompletionInfo {
     set_direction(dir: Gtk.TextDirection): void
     set_double_buffered(double_buffered: boolean): void
     set_events(events: number): void
+    set_focus_on_click(focus_on_click: boolean): void
     set_font_map(font_map: Pango.FontMap | null): void
     set_font_options(options: cairo.FontOptions | null): void
     set_halign(align: Gtk.Align): void
@@ -1087,7 +1107,7 @@ export interface CompletionInfo {
     style_attach(): void
     style_get_property(property_name: string, value: any): void
     thaw_child_notify(): void
-    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number, /* dest_y */ number ]
+    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number | null, /* dest_y */ number | null ]
     trigger_tooltip_query(): void
     unmap(): void
     unparent(): void
@@ -1099,9 +1119,9 @@ export interface CompletionInfo {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1110,10 +1130,10 @@ export interface CompletionInfo {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1130,7 +1150,7 @@ export interface CompletionInfo {
     vfunc_check_resize(): void
     vfunc_child_type(): number
     vfunc_composite_name(child: Gtk.Widget): string
-    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object): void
+    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object | null): void
     vfunc_get_child_property(child: Gtk.Widget, property_id: number, value: any, pspec: GObject.ParamSpec): void
     vfunc_get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     vfunc_remove(widget: Gtk.Widget): void
@@ -1280,7 +1300,7 @@ export interface CompletionInfo {
     connect(sigName: "leave-notify-event", callback: ((obj: CompletionInfo, event: Gdk.EventCrossing) => boolean))
     connect(sigName: "map", callback: ((obj: CompletionInfo) => void))
     connect(sigName: "map-event", callback: ((obj: CompletionInfo, event: Gdk.EventAny) => boolean))
-    connect(sigName: "mnemonic-activate", callback: ((obj: CompletionInfo, arg1: boolean) => boolean))
+    connect(sigName: "mnemonic-activate", callback: ((obj: CompletionInfo, group_cycling: boolean) => boolean))
     connect(sigName: "motion-notify-event", callback: ((obj: CompletionInfo, event: Gdk.EventMotion) => boolean))
     connect(sigName: "move-focus", callback: ((obj: CompletionInfo, direction: Gtk.DirectionType) => void))
     connect(sigName: "parent-set", callback: ((obj: CompletionInfo, old_parent: Gtk.Widget | null) => void))
@@ -1354,6 +1374,7 @@ export interface CompletionInfo {
     connect(sigName: "notify::double-buffered", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::events", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::expand", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::focus-on-click", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::halign", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-default", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-focus", callback: ((obj: CompletionInfo, pspec: GObject.ParamSpec) => void))
@@ -1417,14 +1438,22 @@ export interface CompletionItem {
     priv:CompletionItemPrivate
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
+    /* Methods of GtkSource.CompletionItem */
+    set_gicon(gicon: Gio.Icon | null): void
+    set_icon(icon: GdkPixbuf.Pixbuf | null): void
+    set_icon_name(icon_name: string | null): void
+    set_info(info: string | null): void
+    set_label(label: string | null): void
+    set_markup(markup: string | null): void
+    set_text(text: string | null): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1433,10 +1462,10 @@ export interface CompletionItem {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1466,6 +1495,7 @@ export declare class CompletionItem_Static {
     new(label: string, text: string, icon: GdkPixbuf.Pixbuf | null, info: string | null): CompletionItem
     new_from_stock(label: string | null, text: string, stock: string, info: string | null): CompletionItem
     new_with_markup(markup: string, text: string, icon: GdkPixbuf.Pixbuf | null, info: string | null): CompletionItem
+    new2(): CompletionItem
 }
 export declare var CompletionItem: CompletionItem_Static
 export interface CompletionWords_ConstructProps extends GObject.Object_ConstructProps {
@@ -1501,9 +1531,9 @@ export interface CompletionWords {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1512,10 +1542,10 @@ export interface CompletionWords {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1577,9 +1607,9 @@ export interface File {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1588,10 +1618,10 @@ export interface File {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1640,7 +1670,7 @@ export interface FileLoader {
     get_input_stream(): Gio.InputStream | null
     get_location(): Gio.File | null
     get_newline_type(): NewlineType
-    load_async(io_priority: number, cancellable: Gio.Cancellable | null, progress_callback: Gio.FileProgressCallback | null, progress_callback_data: object, progress_callback_notify: GLib.DestroyNotify | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    load_async(io_priority: number, cancellable: Gio.Cancellable | null, progress_callback: Gio.FileProgressCallback | null, progress_callback_data: object | null, progress_callback_notify: GLib.DestroyNotify | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     load_finish(result: Gio.AsyncResult): boolean
     set_candidate_encodings(candidate_encodings: GLib.SList): void
     /* Methods of GObject.Object */
@@ -1648,9 +1678,9 @@ export interface FileLoader {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1659,10 +1689,10 @@ export interface FileLoader {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1714,7 +1744,7 @@ export interface FileSaver {
     get_flags(): FileSaverFlags
     get_location(): Gio.File
     get_newline_type(): NewlineType
-    save_async(io_priority: number, cancellable: Gio.Cancellable | null, progress_callback: Gio.FileProgressCallback | null, progress_callback_data: object, progress_callback_notify: GLib.DestroyNotify | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    save_async(io_priority: number, cancellable: Gio.Cancellable | null, progress_callback: Gio.FileProgressCallback | null, progress_callback_data: object | null, progress_callback_notify: GLib.DestroyNotify | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     save_finish(result: Gio.AsyncResult): boolean
     set_compression_type(compression_type: CompressionType): void
     set_encoding(encoding: Encoding | null): void
@@ -1725,9 +1755,9 @@ export interface FileSaver {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1736,10 +1766,10 @@ export interface FileSaver {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1785,7 +1815,9 @@ export interface Gutter {
     /* Methods of GtkSource.Gutter */
     get_padding(xpad: number, ypad: number): void
     get_renderer_at_pos(x: number, y: number): GutterRenderer | null
+    get_view(): View
     get_window(): Gdk.Window
+    get_window_type(): Gtk.TextWindowType
     insert(renderer: GutterRenderer, position: number): boolean
     queue_draw(): void
     remove(renderer: GutterRenderer): void
@@ -1796,9 +1828,9 @@ export interface Gutter {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1807,10 +1839,10 @@ export interface Gutter {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1889,9 +1921,9 @@ export interface GutterRenderer {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1900,10 +1932,10 @@ export interface GutterRenderer {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2018,9 +2050,9 @@ export interface GutterRendererPixbuf {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2029,10 +2061,10 @@ export interface GutterRendererPixbuf {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2114,8 +2146,8 @@ export interface GutterRendererText {
     g_type_instance:GObject.TypeInstance
     /* Fields of GObject.Object */
     /* Methods of GtkSource.GutterRendererText */
-    measure(text: string): [ /* width */ number, /* height */ number ]
-    measure_markup(markup: string): [ /* width */ number, /* height */ number ]
+    measure(text: string): [ /* width */ number | null, /* height */ number | null ]
+    measure_markup(markup: string): [ /* width */ number | null, /* height */ number | null ]
     set_markup(markup: string, length: number): void
     set_text(text: string, length: number): void
     /* Methods of GtkSource.GutterRenderer */
@@ -2146,9 +2178,9 @@ export interface GutterRendererText {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2157,10 +2189,10 @@ export interface GutterRendererText {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2242,9 +2274,9 @@ export interface Language {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2253,10 +2285,10 @@ export interface Language {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2303,9 +2335,9 @@ export interface LanguageManager {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2314,10 +2346,10 @@ export interface LanguageManager {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2366,6 +2398,7 @@ export interface Map {
     show_right_margin:boolean
     smart_backspace:boolean
     smart_home_end:SmartHomeEndType
+    readonly space_drawer:SpaceDrawer
     tab_width:number
     /* Properties of Gtk.TextView */
     accepts_tab:boolean
@@ -2401,6 +2434,7 @@ export interface Map {
     double_buffered:boolean
     events:Gdk.EventMask
     expand:boolean
+    focus_on_click:boolean
     halign:Gtk.Align
     has_default:boolean
     has_focus:boolean
@@ -2463,6 +2497,7 @@ export interface Map {
     get_show_right_margin(): boolean
     get_smart_backspace(): boolean
     get_smart_home_end(): SmartHomeEndType
+    get_space_drawer(): SpaceDrawer
     get_tab_width(): number
     get_visual_column(iter: Gtk.TextIter): number
     indent_lines(start: Gtk.TextIter, end: Gtk.TextIter): void
@@ -2502,8 +2537,8 @@ export interface Map {
     get_indent(): number
     get_input_hints(): Gtk.InputHints
     get_input_purpose(): Gtk.InputPurpose
-    get_iter_at_location(x: number, y: number): /* iter */ Gtk.TextIter
-    get_iter_at_position(x: number, y: number): [ /* iter */ Gtk.TextIter, /* trailing */ number | null ]
+    get_iter_at_location(x: number, y: number): [ /* returnType */ boolean, /* iter */ Gtk.TextIter ]
+    get_iter_at_position(x: number, y: number): [ /* returnType */ boolean, /* iter */ Gtk.TextIter, /* trailing */ number | null ]
     get_iter_location(iter: Gtk.TextIter): /* location */ Gdk.Rectangle
     get_justification(): Gtk.Justification
     get_left_margin(): number
@@ -2515,7 +2550,7 @@ export interface Map {
     get_pixels_below_lines(): number
     get_pixels_inside_wrap(): number
     get_right_margin(): number
-    get_tabs(): Pango.TabArray
+    get_tabs(): Pango.TabArray | null
     get_top_margin(): number
     get_vadjustment(): Gtk.Adjustment
     get_visible_rect(): /* visible_rect */ Gdk.Rectangle
@@ -2526,6 +2561,7 @@ export interface Map {
     move_mark_onscreen(mark: Gtk.TextMark): boolean
     move_visually(iter: Gtk.TextIter, count: number): boolean
     place_cursor_onscreen(): boolean
+    reset_cursor_blink(): void
     reset_im_context(): void
     scroll_mark_onscreen(mark: Gtk.TextMark): void
     scroll_to_iter(iter: Gtk.TextIter, within_margin: number, use_align: boolean, xalign: number, yalign: number): boolean
@@ -2559,14 +2595,14 @@ export interface Map {
     child_notify_by_pspec(child: Gtk.Widget, pspec: GObject.ParamSpec): void
     child_set_property(child: Gtk.Widget, property_name: string, value: any): void
     child_type(): number
-    forall(callback: Gtk.Callback, callback_data: object): void
-    foreach(callback: Gtk.Callback, callback_data: object): void
+    forall(callback: Gtk.Callback, callback_data: object | null): void
+    foreach(callback: Gtk.Callback, callback_data: object | null): void
     get_border_width(): number
     get_children(): GLib.List
     get_focus_chain(): [ /* returnType */ boolean, /* focusable_widgets */ GLib.List ]
-    get_focus_child(): Gtk.Widget
-    get_focus_hadjustment(): Gtk.Adjustment
-    get_focus_vadjustment(): Gtk.Adjustment
+    get_focus_child(): Gtk.Widget | null
+    get_focus_hadjustment(): Gtk.Adjustment | null
+    get_focus_vadjustment(): Gtk.Adjustment | null
     get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     get_resize_mode(): Gtk.ResizeMode
     propagate_draw(child: Gtk.Widget, cr: cairo.Context): void
@@ -2586,7 +2622,7 @@ export interface Map {
     add_device_events(device: Gdk.Device, events: Gdk.EventMask): void
     add_events(events: number): void
     add_mnemonic_label(label: Gtk.Widget): void
-    add_tick_callback(callback: Gtk.TickCallback, user_data: object, notify: GLib.DestroyNotify): number
+    add_tick_callback(callback: Gtk.TickCallback, user_data: object | null, notify: GLib.DestroyNotify): number
     can_activate_accel(signal_id: number): boolean
     child_focus(direction: Gtk.DirectionType): boolean
     child_notify(child_property: string): void
@@ -2604,7 +2640,7 @@ export interface Map {
     drag_dest_add_text_targets(): void
     drag_dest_add_uri_targets(): void
     drag_dest_find_target(context: Gdk.DragContext, target_list: Gtk.TargetList | null): Gdk.Atom
-    drag_dest_get_target_list(): Gtk.TargetList
+    drag_dest_get_target_list(): Gtk.TargetList | null
     drag_dest_get_track_motion(): boolean
     drag_dest_set(flags: Gtk.DestDefaults, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_dest_set_proxy(proxy_window: Gdk.Window, protocol: Gdk.DragProtocol, use_coordinates: boolean): void
@@ -2616,7 +2652,7 @@ export interface Map {
     drag_source_add_image_targets(): void
     drag_source_add_text_targets(): void
     drag_source_add_uri_targets(): void
-    drag_source_get_target_list(): Gtk.TargetList
+    drag_source_get_target_list(): Gtk.TargetList | null
     drag_source_set(start_button_mask: Gdk.ModifierType, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_source_set_icon_gicon(icon: Gio.Icon): void
     drag_source_set_icon_name(icon_name: string): void
@@ -2634,6 +2670,7 @@ export interface Map {
     get_action_group(prefix: string): Gio.ActionGroup | null
     get_allocated_baseline(): number
     get_allocated_height(): number
+    get_allocated_size(): [ /* allocation */ Gtk.Allocation, /* baseline */ number | null ]
     get_allocated_width(): number
     get_allocation(): /* allocation */ Gtk.Allocation
     get_ancestor(widget_type: number): Gtk.Widget | null
@@ -2651,9 +2688,10 @@ export interface Map {
     get_display(): Gdk.Display
     get_double_buffered(): boolean
     get_events(): number
+    get_focus_on_click(): boolean
     get_font_map(): Pango.FontMap | null
     get_font_options(): cairo.FontOptions | null
-    get_frame_clock(): Gdk.FrameClock
+    get_frame_clock(): Gdk.FrameClock | null
     get_halign(): Gtk.Align
     get_has_tooltip(): boolean
     get_has_window(): boolean
@@ -2673,7 +2711,7 @@ export interface Map {
     get_opacity(): number
     get_pango_context(): Pango.Context
     get_parent(): Gtk.Widget | null
-    get_parent_window(): Gdk.Window
+    get_parent_window(): Gdk.Window | null
     get_path(): Gtk.WidgetPath
     get_pointer(): [ /* x */ number | null, /* y */ number | null ]
     get_preferred_height(): [ /* minimum_height */ number | null, /* natural_height */ number | null ]
@@ -2708,7 +2746,7 @@ export interface Map {
     get_vexpand_set(): boolean
     get_visible(): boolean
     get_visual(): Gdk.Visual
-    get_window(): Gdk.Window
+    get_window(): Gdk.Window | null
     grab_add(): void
     grab_default(): void
     grab_focus(): void
@@ -2723,7 +2761,7 @@ export interface Map {
     init_template(): void
     input_shape_combine_region(region: cairo.Region | null): void
     insert_action_group(name: string, group: Gio.ActionGroup | null): void
-    intersect(area: Gdk.Rectangle, intersection: Gdk.Rectangle | null): boolean
+    intersect(area: Gdk.Rectangle): [ /* returnType */ boolean, /* intersection */ Gdk.Rectangle | null ]
     is_ancestor(ancestor: Gtk.Widget): boolean
     is_composited(): boolean
     is_drawable(): boolean
@@ -2749,6 +2787,7 @@ export interface Map {
     override_font(font_desc: Pango.FontDescription | null): void
     override_symbolic_color(name: string, color: Gdk.RGBA | null): void
     path(): [ /* path_length */ number | null, /* path */ string | null, /* path_reversed */ string | null ]
+    queue_allocate(): void
     queue_compute_expand(): void
     queue_draw(): void
     queue_draw_area(x: number, y: number, width: number, height: number): void
@@ -2761,7 +2800,7 @@ export interface Map {
     remove_accelerator(accel_group: Gtk.AccelGroup, accel_key: number, accel_mods: Gdk.ModifierType): boolean
     remove_mnemonic_label(label: Gtk.Widget): void
     remove_tick_callback(id: number): void
-    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf
+    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf | null
     render_icon_pixbuf(stock_id: string, size: number): GdkPixbuf.Pixbuf | null
     reparent(new_parent: Gtk.Widget): void
     reset_rc_styles(): void
@@ -2781,6 +2820,7 @@ export interface Map {
     set_direction(dir: Gtk.TextDirection): void
     set_double_buffered(double_buffered: boolean): void
     set_events(events: number): void
+    set_focus_on_click(focus_on_click: boolean): void
     set_font_map(font_map: Pango.FontMap | null): void
     set_font_options(options: cairo.FontOptions | null): void
     set_halign(align: Gtk.Align): void
@@ -2828,7 +2868,7 @@ export interface Map {
     style_attach(): void
     style_get_property(property_name: string, value: any): void
     thaw_child_notify(): void
-    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number, /* dest_y */ number ]
+    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number | null, /* dest_y */ number | null ]
     trigger_tooltip_query(): void
     unmap(): void
     unparent(): void
@@ -2840,9 +2880,9 @@ export interface Map {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2851,10 +2891,10 @@ export interface Map {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2883,7 +2923,7 @@ export interface Map {
     vfunc_check_resize(): void
     vfunc_child_type(): number
     vfunc_composite_name(child: Gtk.Widget): string
-    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object): void
+    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object | null): void
     vfunc_get_child_property(child: Gtk.Widget, property_id: number, value: any, pspec: GObject.ParamSpec): void
     vfunc_get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     vfunc_remove(widget: Gtk.Widget): void
@@ -3053,7 +3093,7 @@ export interface Map {
     connect(sigName: "leave-notify-event", callback: ((obj: Map, event: Gdk.EventCrossing) => boolean))
     connect(sigName: "map", callback: ((obj: Map) => void))
     connect(sigName: "map-event", callback: ((obj: Map, event: Gdk.EventAny) => boolean))
-    connect(sigName: "mnemonic-activate", callback: ((obj: Map, arg1: boolean) => boolean))
+    connect(sigName: "mnemonic-activate", callback: ((obj: Map, group_cycling: boolean) => boolean))
     connect(sigName: "motion-notify-event", callback: ((obj: Map, event: Gdk.EventMotion) => boolean))
     connect(sigName: "move-focus", callback: ((obj: Map, direction: Gtk.DirectionType) => void))
     connect(sigName: "parent-set", callback: ((obj: Map, old_parent: Gtk.Widget | null) => void))
@@ -3101,6 +3141,7 @@ export interface Map {
     connect(sigName: "notify::show-right-margin", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::smart-backspace", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::smart-home-end", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::space-drawer", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::tab-width", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::accepts-tab", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::bottom-margin", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
@@ -3133,6 +3174,7 @@ export interface Map {
     connect(sigName: "notify::double-buffered", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::events", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::expand", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::focus-on-click", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::halign", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-default", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-focus", callback: ((obj: Map, pspec: GObject.ParamSpec) => void))
@@ -3193,7 +3235,7 @@ export interface Mark {
     get_buffer(): Gtk.TextBuffer
     get_deleted(): boolean
     get_left_gravity(): boolean
-    get_name(): string
+    get_name(): string | null
     get_visible(): boolean
     set_visible(setting: boolean): void
     /* Methods of GObject.Object */
@@ -3201,9 +3243,9 @@ export interface Mark {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3212,10 +3254,10 @@ export interface Mark {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3274,9 +3316,9 @@ export interface MarkAttributes {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3285,10 +3327,10 @@ export interface MarkAttributes {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3391,9 +3433,9 @@ export interface PrintCompositor {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3402,10 +3444,10 @@ export interface PrintCompositor {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3440,6 +3482,69 @@ export declare class PrintCompositor_Static {
     new_from_view(view: View): PrintCompositor
 }
 export declare var PrintCompositor: PrintCompositor_Static
+export interface Region_ConstructProps extends GObject.Object_ConstructProps {
+    buffer?:Gtk.TextBuffer
+}
+export interface Region {
+    /* Properties of GtkSource.Region */
+    /* Fields of GtkSource.Region */
+    parent_instance:GObject.Object
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of GtkSource.Region */
+    add_region(region_to_add: Region | null): void
+    add_subregion(_start: Gtk.TextIter, _end: Gtk.TextIter): void
+    get_bounds(): [ /* returnType */ boolean, /* start */ Gtk.TextIter | null, /* end */ Gtk.TextIter | null ]
+    get_buffer(): Gtk.TextBuffer | null
+    get_start_region_iter(): /* iter */ RegionIter
+    intersect_region(region2: Region | null): Region | null
+    intersect_subregion(_start: Gtk.TextIter, _end: Gtk.TextIter): Region | null
+    is_empty(): boolean
+    subtract_region(region_to_subtract: Region | null): void
+    subtract_subregion(_start: Gtk.TextIter, _end: Gtk.TextIter): void
+    to_string(): string | null
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: Region, pspec: GObject.ParamSpec) => void))
+}
+export interface Region_Static {
+    name: string
+    new (config?: Region_ConstructProps): Region
+}
+export declare class Region_Static {
+    new(buffer: Gtk.TextBuffer): Region
+}
+export declare var Region: Region_Static
 export interface SearchContext_ConstructProps extends GObject.Object_ConstructProps {
     buffer?:Buffer
     highlight?:boolean
@@ -3460,11 +3565,15 @@ export interface SearchContext {
     g_type_instance:GObject.TypeInstance
     /* Methods of GtkSource.SearchContext */
     backward(iter: Gtk.TextIter): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null ]
-    backward_async(iter: Gtk.TextIter, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    backward2(iter: Gtk.TextIter): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null, /* has_wrapped_around */ boolean | null ]
+    backward_async(iter: Gtk.TextIter, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     backward_finish(result: Gio.AsyncResult): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null ]
+    backward_finish2(result: Gio.AsyncResult): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null, /* has_wrapped_around */ boolean | null ]
     forward(iter: Gtk.TextIter): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null ]
-    forward_async(iter: Gtk.TextIter, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    forward2(iter: Gtk.TextIter): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null, /* has_wrapped_around */ boolean | null ]
+    forward_async(iter: Gtk.TextIter, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     forward_finish(result: Gio.AsyncResult): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null ]
+    forward_finish2(result: Gio.AsyncResult): [ /* returnType */ boolean, /* match_start */ Gtk.TextIter | null, /* match_end */ Gtk.TextIter | null, /* has_wrapped_around */ boolean | null ]
     get_buffer(): Buffer
     get_highlight(): boolean
     get_match_style(): Style
@@ -3473,6 +3582,7 @@ export interface SearchContext {
     get_regex_error(): GLib.Error | null
     get_settings(): SearchSettings
     replace(match_start: Gtk.TextIter, match_end: Gtk.TextIter, replace: string, replace_length: number): boolean
+    replace2(match_start: Gtk.TextIter, match_end: Gtk.TextIter, replace: string, replace_length: number): boolean
     replace_all(replace: string, replace_length: number): number
     set_highlight(highlight: boolean): void
     set_match_style(match_style: Style | null): void
@@ -3482,9 +3592,9 @@ export interface SearchContext {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3493,10 +3603,10 @@ export interface SearchContext {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3559,9 +3669,9 @@ export interface SearchSettings {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3570,10 +3680,10 @@ export interface SearchSettings {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3601,6 +3711,71 @@ export declare class SearchSettings_Static {
     new(): SearchSettings
 }
 export declare var SearchSettings: SearchSettings_Static
+export interface SpaceDrawer_ConstructProps extends GObject.Object_ConstructProps {
+    enable_matrix?:boolean
+    matrix?:GLib.Variant
+}
+export interface SpaceDrawer {
+    /* Properties of GtkSource.SpaceDrawer */
+    enable_matrix:boolean
+    matrix:GLib.Variant
+    /* Fields of GtkSource.SpaceDrawer */
+    parent:GObject.Object
+    priv:SpaceDrawerPrivate
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of GtkSource.SpaceDrawer */
+    bind_matrix_setting(settings: Gio.Settings, key: string, flags: Gio.SettingsBindFlags): void
+    get_enable_matrix(): boolean
+    get_matrix(): GLib.Variant
+    get_types_for_locations(locations: SpaceLocationFlags): SpaceTypeFlags
+    set_enable_matrix(enable_matrix: boolean): void
+    set_matrix(matrix: GLib.Variant | null): void
+    set_types_for_locations(locations: SpaceLocationFlags, types: SpaceTypeFlags): void
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: SpaceDrawer, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::enable-matrix", callback: ((obj: SpaceDrawer, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::matrix", callback: ((obj: SpaceDrawer, pspec: GObject.ParamSpec) => void))
+}
+export interface SpaceDrawer_Static {
+    name: string
+    new (config?: SpaceDrawer_ConstructProps): SpaceDrawer
+}
+export declare class SpaceDrawer_Static {
+    new(): SpaceDrawer
+}
+export declare var SpaceDrawer: SpaceDrawer_Static
 export interface Style_ConstructProps extends GObject.Object_ConstructProps {
     background?:string
     background_set?:boolean
@@ -3627,15 +3802,16 @@ export interface Style {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of GtkSource.Style */
+    apply(tag: Gtk.TextTag): void
     copy(): Style
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3644,10 +3820,10 @@ export interface Style {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3692,9 +3868,9 @@ export interface StyleScheme {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3703,10 +3879,10 @@ export interface StyleScheme {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3734,7 +3910,6 @@ export interface StyleSchemeChooserButton_ConstructProps extends Gtk.Button_Cons
 export interface StyleSchemeChooserButton {
     /* Properties of Gtk.Button */
     always_show_image:boolean
-    focus_on_click:boolean
     image:Gtk.Widget
     image_position:Gtk.PositionType
     label:string
@@ -3755,6 +3930,7 @@ export interface StyleSchemeChooserButton {
     double_buffered:boolean
     events:Gdk.EventMask
     expand:boolean
+    focus_on_click:boolean
     halign:Gtk.Align
     has_default:boolean
     has_focus:boolean
@@ -3804,7 +3980,7 @@ export interface StyleSchemeChooserButton {
     get_always_show_image(): boolean
     get_event_window(): Gdk.Window
     get_focus_on_click(): boolean
-    get_image(): Gtk.Widget
+    get_image(): Gtk.Widget | null
     get_image_position(): Gtk.PositionType
     get_label(): string
     get_relief(): Gtk.ReliefStyle
@@ -3823,7 +3999,7 @@ export interface StyleSchemeChooserButton {
     set_use_stock(use_stock: boolean): void
     set_use_underline(use_underline: boolean): void
     /* Methods of Gtk.Bin */
-    get_child(): Gtk.Widget
+    get_child(): Gtk.Widget | null
     /* Methods of Gtk.Container */
     add(widget: Gtk.Widget): void
     check_resize(): void
@@ -3831,14 +4007,14 @@ export interface StyleSchemeChooserButton {
     child_notify_by_pspec(child: Gtk.Widget, pspec: GObject.ParamSpec): void
     child_set_property(child: Gtk.Widget, property_name: string, value: any): void
     child_type(): number
-    forall(callback: Gtk.Callback, callback_data: object): void
-    foreach(callback: Gtk.Callback, callback_data: object): void
+    forall(callback: Gtk.Callback, callback_data: object | null): void
+    foreach(callback: Gtk.Callback, callback_data: object | null): void
     get_border_width(): number
     get_children(): GLib.List
     get_focus_chain(): [ /* returnType */ boolean, /* focusable_widgets */ GLib.List ]
-    get_focus_child(): Gtk.Widget
-    get_focus_hadjustment(): Gtk.Adjustment
-    get_focus_vadjustment(): Gtk.Adjustment
+    get_focus_child(): Gtk.Widget | null
+    get_focus_hadjustment(): Gtk.Adjustment | null
+    get_focus_vadjustment(): Gtk.Adjustment | null
     get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     get_resize_mode(): Gtk.ResizeMode
     propagate_draw(child: Gtk.Widget, cr: cairo.Context): void
@@ -3858,7 +4034,7 @@ export interface StyleSchemeChooserButton {
     add_device_events(device: Gdk.Device, events: Gdk.EventMask): void
     add_events(events: number): void
     add_mnemonic_label(label: Gtk.Widget): void
-    add_tick_callback(callback: Gtk.TickCallback, user_data: object, notify: GLib.DestroyNotify): number
+    add_tick_callback(callback: Gtk.TickCallback, user_data: object | null, notify: GLib.DestroyNotify): number
     can_activate_accel(signal_id: number): boolean
     child_focus(direction: Gtk.DirectionType): boolean
     child_notify(child_property: string): void
@@ -3876,7 +4052,7 @@ export interface StyleSchemeChooserButton {
     drag_dest_add_text_targets(): void
     drag_dest_add_uri_targets(): void
     drag_dest_find_target(context: Gdk.DragContext, target_list: Gtk.TargetList | null): Gdk.Atom
-    drag_dest_get_target_list(): Gtk.TargetList
+    drag_dest_get_target_list(): Gtk.TargetList | null
     drag_dest_get_track_motion(): boolean
     drag_dest_set(flags: Gtk.DestDefaults, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_dest_set_proxy(proxy_window: Gdk.Window, protocol: Gdk.DragProtocol, use_coordinates: boolean): void
@@ -3888,7 +4064,7 @@ export interface StyleSchemeChooserButton {
     drag_source_add_image_targets(): void
     drag_source_add_text_targets(): void
     drag_source_add_uri_targets(): void
-    drag_source_get_target_list(): Gtk.TargetList
+    drag_source_get_target_list(): Gtk.TargetList | null
     drag_source_set(start_button_mask: Gdk.ModifierType, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_source_set_icon_gicon(icon: Gio.Icon): void
     drag_source_set_icon_name(icon_name: string): void
@@ -3906,6 +4082,7 @@ export interface StyleSchemeChooserButton {
     get_action_group(prefix: string): Gio.ActionGroup | null
     get_allocated_baseline(): number
     get_allocated_height(): number
+    get_allocated_size(): [ /* allocation */ Gtk.Allocation, /* baseline */ number | null ]
     get_allocated_width(): number
     get_allocation(): /* allocation */ Gtk.Allocation
     get_ancestor(widget_type: number): Gtk.Widget | null
@@ -3925,7 +4102,7 @@ export interface StyleSchemeChooserButton {
     get_events(): number
     get_font_map(): Pango.FontMap | null
     get_font_options(): cairo.FontOptions | null
-    get_frame_clock(): Gdk.FrameClock
+    get_frame_clock(): Gdk.FrameClock | null
     get_halign(): Gtk.Align
     get_has_tooltip(): boolean
     get_has_window(): boolean
@@ -3945,7 +4122,7 @@ export interface StyleSchemeChooserButton {
     get_opacity(): number
     get_pango_context(): Pango.Context
     get_parent(): Gtk.Widget | null
-    get_parent_window(): Gdk.Window
+    get_parent_window(): Gdk.Window | null
     get_path(): Gtk.WidgetPath
     get_pointer(): [ /* x */ number | null, /* y */ number | null ]
     get_preferred_height(): [ /* minimum_height */ number | null, /* natural_height */ number | null ]
@@ -3980,7 +4157,7 @@ export interface StyleSchemeChooserButton {
     get_vexpand_set(): boolean
     get_visible(): boolean
     get_visual(): Gdk.Visual
-    get_window(): Gdk.Window
+    get_window(): Gdk.Window | null
     grab_add(): void
     grab_default(): void
     grab_focus(): void
@@ -3995,7 +4172,7 @@ export interface StyleSchemeChooserButton {
     init_template(): void
     input_shape_combine_region(region: cairo.Region | null): void
     insert_action_group(name: string, group: Gio.ActionGroup | null): void
-    intersect(area: Gdk.Rectangle, intersection: Gdk.Rectangle | null): boolean
+    intersect(area: Gdk.Rectangle): [ /* returnType */ boolean, /* intersection */ Gdk.Rectangle | null ]
     is_ancestor(ancestor: Gtk.Widget): boolean
     is_composited(): boolean
     is_drawable(): boolean
@@ -4021,6 +4198,7 @@ export interface StyleSchemeChooserButton {
     override_font(font_desc: Pango.FontDescription | null): void
     override_symbolic_color(name: string, color: Gdk.RGBA | null): void
     path(): [ /* path_length */ number | null, /* path */ string | null, /* path_reversed */ string | null ]
+    queue_allocate(): void
     queue_compute_expand(): void
     queue_draw(): void
     queue_draw_area(x: number, y: number, width: number, height: number): void
@@ -4033,7 +4211,7 @@ export interface StyleSchemeChooserButton {
     remove_accelerator(accel_group: Gtk.AccelGroup, accel_key: number, accel_mods: Gdk.ModifierType): boolean
     remove_mnemonic_label(label: Gtk.Widget): void
     remove_tick_callback(id: number): void
-    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf
+    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf | null
     render_icon_pixbuf(stock_id: string, size: number): GdkPixbuf.Pixbuf | null
     reparent(new_parent: Gtk.Widget): void
     reset_rc_styles(): void
@@ -4100,7 +4278,7 @@ export interface StyleSchemeChooserButton {
     style_attach(): void
     style_get_property(property_name: string, value: any): void
     thaw_child_notify(): void
-    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number, /* dest_y */ number ]
+    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number | null, /* dest_y */ number | null ]
     trigger_tooltip_query(): void
     unmap(): void
     unparent(): void
@@ -4112,9 +4290,9 @@ export interface StyleSchemeChooserButton {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4123,10 +4301,10 @@ export interface StyleSchemeChooserButton {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4142,7 +4320,7 @@ export interface StyleSchemeChooserButton {
     vfunc_check_resize(): void
     vfunc_child_type(): number
     vfunc_composite_name(child: Gtk.Widget): string
-    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object): void
+    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object | null): void
     vfunc_get_child_property(child: Gtk.Widget, property_id: number, value: any, pspec: GObject.ParamSpec): void
     vfunc_get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     vfunc_remove(widget: Gtk.Widget): void
@@ -4291,7 +4469,7 @@ export interface StyleSchemeChooserButton {
     connect(sigName: "leave-notify-event", callback: ((obj: StyleSchemeChooserButton, event: Gdk.EventCrossing) => boolean))
     connect(sigName: "map", callback: ((obj: StyleSchemeChooserButton) => void))
     connect(sigName: "map-event", callback: ((obj: StyleSchemeChooserButton, event: Gdk.EventAny) => boolean))
-    connect(sigName: "mnemonic-activate", callback: ((obj: StyleSchemeChooserButton, arg1: boolean) => boolean))
+    connect(sigName: "mnemonic-activate", callback: ((obj: StyleSchemeChooserButton, group_cycling: boolean) => boolean))
     connect(sigName: "motion-notify-event", callback: ((obj: StyleSchemeChooserButton, event: Gdk.EventMotion) => boolean))
     connect(sigName: "move-focus", callback: ((obj: StyleSchemeChooserButton, direction: Gtk.DirectionType) => void))
     connect(sigName: "parent-set", callback: ((obj: StyleSchemeChooserButton, old_parent: Gtk.Widget | null) => void))
@@ -4324,7 +4502,6 @@ export interface StyleSchemeChooserButton {
     /* Signals of GObject.Object */
     connect(sigName: "notify", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::always-show-image", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
-    connect(sigName: "notify::focus-on-click", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::image", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::image-position", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::label", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
@@ -4343,6 +4520,7 @@ export interface StyleSchemeChooserButton {
     connect(sigName: "notify::double-buffered", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::events", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::expand", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::focus-on-click", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::halign", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-default", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-focus", callback: ((obj: StyleSchemeChooserButton, pspec: GObject.ParamSpec) => void))
@@ -4398,6 +4576,7 @@ export interface StyleSchemeChooserWidget {
     double_buffered:boolean
     events:Gdk.EventMask
     expand:boolean
+    focus_on_click:boolean
     halign:Gtk.Align
     has_default:boolean
     has_focus:boolean
@@ -4440,7 +4619,7 @@ export interface StyleSchemeChooserWidget {
     g_type_instance:GObject.TypeInstance
     /* Fields of GObject.Object */
     /* Methods of Gtk.Bin */
-    get_child(): Gtk.Widget
+    get_child(): Gtk.Widget | null
     /* Methods of Gtk.Container */
     add(widget: Gtk.Widget): void
     check_resize(): void
@@ -4448,14 +4627,14 @@ export interface StyleSchemeChooserWidget {
     child_notify_by_pspec(child: Gtk.Widget, pspec: GObject.ParamSpec): void
     child_set_property(child: Gtk.Widget, property_name: string, value: any): void
     child_type(): number
-    forall(callback: Gtk.Callback, callback_data: object): void
-    foreach(callback: Gtk.Callback, callback_data: object): void
+    forall(callback: Gtk.Callback, callback_data: object | null): void
+    foreach(callback: Gtk.Callback, callback_data: object | null): void
     get_border_width(): number
     get_children(): GLib.List
     get_focus_chain(): [ /* returnType */ boolean, /* focusable_widgets */ GLib.List ]
-    get_focus_child(): Gtk.Widget
-    get_focus_hadjustment(): Gtk.Adjustment
-    get_focus_vadjustment(): Gtk.Adjustment
+    get_focus_child(): Gtk.Widget | null
+    get_focus_hadjustment(): Gtk.Adjustment | null
+    get_focus_vadjustment(): Gtk.Adjustment | null
     get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     get_resize_mode(): Gtk.ResizeMode
     propagate_draw(child: Gtk.Widget, cr: cairo.Context): void
@@ -4475,7 +4654,7 @@ export interface StyleSchemeChooserWidget {
     add_device_events(device: Gdk.Device, events: Gdk.EventMask): void
     add_events(events: number): void
     add_mnemonic_label(label: Gtk.Widget): void
-    add_tick_callback(callback: Gtk.TickCallback, user_data: object, notify: GLib.DestroyNotify): number
+    add_tick_callback(callback: Gtk.TickCallback, user_data: object | null, notify: GLib.DestroyNotify): number
     can_activate_accel(signal_id: number): boolean
     child_focus(direction: Gtk.DirectionType): boolean
     child_notify(child_property: string): void
@@ -4493,7 +4672,7 @@ export interface StyleSchemeChooserWidget {
     drag_dest_add_text_targets(): void
     drag_dest_add_uri_targets(): void
     drag_dest_find_target(context: Gdk.DragContext, target_list: Gtk.TargetList | null): Gdk.Atom
-    drag_dest_get_target_list(): Gtk.TargetList
+    drag_dest_get_target_list(): Gtk.TargetList | null
     drag_dest_get_track_motion(): boolean
     drag_dest_set(flags: Gtk.DestDefaults, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_dest_set_proxy(proxy_window: Gdk.Window, protocol: Gdk.DragProtocol, use_coordinates: boolean): void
@@ -4505,7 +4684,7 @@ export interface StyleSchemeChooserWidget {
     drag_source_add_image_targets(): void
     drag_source_add_text_targets(): void
     drag_source_add_uri_targets(): void
-    drag_source_get_target_list(): Gtk.TargetList
+    drag_source_get_target_list(): Gtk.TargetList | null
     drag_source_set(start_button_mask: Gdk.ModifierType, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_source_set_icon_gicon(icon: Gio.Icon): void
     drag_source_set_icon_name(icon_name: string): void
@@ -4523,6 +4702,7 @@ export interface StyleSchemeChooserWidget {
     get_action_group(prefix: string): Gio.ActionGroup | null
     get_allocated_baseline(): number
     get_allocated_height(): number
+    get_allocated_size(): [ /* allocation */ Gtk.Allocation, /* baseline */ number | null ]
     get_allocated_width(): number
     get_allocation(): /* allocation */ Gtk.Allocation
     get_ancestor(widget_type: number): Gtk.Widget | null
@@ -4540,9 +4720,10 @@ export interface StyleSchemeChooserWidget {
     get_display(): Gdk.Display
     get_double_buffered(): boolean
     get_events(): number
+    get_focus_on_click(): boolean
     get_font_map(): Pango.FontMap | null
     get_font_options(): cairo.FontOptions | null
-    get_frame_clock(): Gdk.FrameClock
+    get_frame_clock(): Gdk.FrameClock | null
     get_halign(): Gtk.Align
     get_has_tooltip(): boolean
     get_has_window(): boolean
@@ -4562,7 +4743,7 @@ export interface StyleSchemeChooserWidget {
     get_opacity(): number
     get_pango_context(): Pango.Context
     get_parent(): Gtk.Widget | null
-    get_parent_window(): Gdk.Window
+    get_parent_window(): Gdk.Window | null
     get_path(): Gtk.WidgetPath
     get_pointer(): [ /* x */ number | null, /* y */ number | null ]
     get_preferred_height(): [ /* minimum_height */ number | null, /* natural_height */ number | null ]
@@ -4597,7 +4778,7 @@ export interface StyleSchemeChooserWidget {
     get_vexpand_set(): boolean
     get_visible(): boolean
     get_visual(): Gdk.Visual
-    get_window(): Gdk.Window
+    get_window(): Gdk.Window | null
     grab_add(): void
     grab_default(): void
     grab_focus(): void
@@ -4612,7 +4793,7 @@ export interface StyleSchemeChooserWidget {
     init_template(): void
     input_shape_combine_region(region: cairo.Region | null): void
     insert_action_group(name: string, group: Gio.ActionGroup | null): void
-    intersect(area: Gdk.Rectangle, intersection: Gdk.Rectangle | null): boolean
+    intersect(area: Gdk.Rectangle): [ /* returnType */ boolean, /* intersection */ Gdk.Rectangle | null ]
     is_ancestor(ancestor: Gtk.Widget): boolean
     is_composited(): boolean
     is_drawable(): boolean
@@ -4638,6 +4819,7 @@ export interface StyleSchemeChooserWidget {
     override_font(font_desc: Pango.FontDescription | null): void
     override_symbolic_color(name: string, color: Gdk.RGBA | null): void
     path(): [ /* path_length */ number | null, /* path */ string | null, /* path_reversed */ string | null ]
+    queue_allocate(): void
     queue_compute_expand(): void
     queue_draw(): void
     queue_draw_area(x: number, y: number, width: number, height: number): void
@@ -4650,7 +4832,7 @@ export interface StyleSchemeChooserWidget {
     remove_accelerator(accel_group: Gtk.AccelGroup, accel_key: number, accel_mods: Gdk.ModifierType): boolean
     remove_mnemonic_label(label: Gtk.Widget): void
     remove_tick_callback(id: number): void
-    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf
+    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf | null
     render_icon_pixbuf(stock_id: string, size: number): GdkPixbuf.Pixbuf | null
     reparent(new_parent: Gtk.Widget): void
     reset_rc_styles(): void
@@ -4670,6 +4852,7 @@ export interface StyleSchemeChooserWidget {
     set_direction(dir: Gtk.TextDirection): void
     set_double_buffered(double_buffered: boolean): void
     set_events(events: number): void
+    set_focus_on_click(focus_on_click: boolean): void
     set_font_map(font_map: Pango.FontMap | null): void
     set_font_options(options: cairo.FontOptions | null): void
     set_halign(align: Gtk.Align): void
@@ -4717,7 +4900,7 @@ export interface StyleSchemeChooserWidget {
     style_attach(): void
     style_get_property(property_name: string, value: any): void
     thaw_child_notify(): void
-    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number, /* dest_y */ number ]
+    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number | null, /* dest_y */ number | null ]
     trigger_tooltip_query(): void
     unmap(): void
     unparent(): void
@@ -4729,9 +4912,9 @@ export interface StyleSchemeChooserWidget {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4740,10 +4923,10 @@ export interface StyleSchemeChooserWidget {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4752,7 +4935,7 @@ export interface StyleSchemeChooserWidget {
     vfunc_check_resize(): void
     vfunc_child_type(): number
     vfunc_composite_name(child: Gtk.Widget): string
-    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object): void
+    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object | null): void
     vfunc_get_child_property(child: Gtk.Widget, property_id: number, value: any, pspec: GObject.ParamSpec): void
     vfunc_get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     vfunc_remove(widget: Gtk.Widget): void
@@ -4894,7 +5077,7 @@ export interface StyleSchemeChooserWidget {
     connect(sigName: "leave-notify-event", callback: ((obj: StyleSchemeChooserWidget, event: Gdk.EventCrossing) => boolean))
     connect(sigName: "map", callback: ((obj: StyleSchemeChooserWidget) => void))
     connect(sigName: "map-event", callback: ((obj: StyleSchemeChooserWidget, event: Gdk.EventAny) => boolean))
-    connect(sigName: "mnemonic-activate", callback: ((obj: StyleSchemeChooserWidget, arg1: boolean) => boolean))
+    connect(sigName: "mnemonic-activate", callback: ((obj: StyleSchemeChooserWidget, group_cycling: boolean) => boolean))
     connect(sigName: "motion-notify-event", callback: ((obj: StyleSchemeChooserWidget, event: Gdk.EventMotion) => boolean))
     connect(sigName: "move-focus", callback: ((obj: StyleSchemeChooserWidget, direction: Gtk.DirectionType) => void))
     connect(sigName: "parent-set", callback: ((obj: StyleSchemeChooserWidget, old_parent: Gtk.Widget | null) => void))
@@ -4936,6 +5119,7 @@ export interface StyleSchemeChooserWidget {
     connect(sigName: "notify::double-buffered", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::events", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::expand", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::focus-on-click", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::halign", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-default", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-focus", callback: ((obj: StyleSchemeChooserWidget, pspec: GObject.ParamSpec) => void))
@@ -5001,9 +5185,9 @@ export interface StyleSchemeManager {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5012,10 +5196,10 @@ export interface StyleSchemeManager {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5041,6 +5225,220 @@ export declare class StyleSchemeManager_Static {
     get_default(): StyleSchemeManager
 }
 export declare var StyleSchemeManager: StyleSchemeManager_Static
+export interface Tag_ConstructProps extends Gtk.TextTag_ConstructProps {
+    draw_spaces?:boolean
+    draw_spaces_set?:boolean
+}
+export interface Tag {
+    /* Properties of GtkSource.Tag */
+    draw_spaces:boolean
+    draw_spaces_set:boolean
+    /* Properties of Gtk.TextTag */
+    accumulative_margin:boolean
+    background:string
+    background_full_height:boolean
+    background_full_height_set:boolean
+    background_gdk:Gdk.Color
+    background_rgba:Gdk.RGBA
+    background_set:boolean
+    direction:Gtk.TextDirection
+    editable:boolean
+    editable_set:boolean
+    fallback:boolean
+    fallback_set:boolean
+    family:string
+    family_set:boolean
+    font:string
+    font_desc:Pango.FontDescription
+    font_features:string
+    font_features_set:boolean
+    foreground:string
+    foreground_gdk:Gdk.Color
+    foreground_rgba:Gdk.RGBA
+    foreground_set:boolean
+    indent:number
+    indent_set:boolean
+    invisible:boolean
+    invisible_set:boolean
+    justification:Gtk.Justification
+    justification_set:boolean
+    language:string
+    language_set:boolean
+    left_margin:number
+    left_margin_set:boolean
+    letter_spacing:number
+    letter_spacing_set:boolean
+    paragraph_background:string
+    paragraph_background_gdk:Gdk.Color
+    paragraph_background_rgba:Gdk.RGBA
+    paragraph_background_set:boolean
+    pixels_above_lines:number
+    pixels_above_lines_set:boolean
+    pixels_below_lines:number
+    pixels_below_lines_set:boolean
+    pixels_inside_wrap:number
+    pixels_inside_wrap_set:boolean
+    right_margin:number
+    right_margin_set:boolean
+    rise:number
+    rise_set:boolean
+    scale:number
+    scale_set:boolean
+    size:number
+    size_points:number
+    size_set:boolean
+    stretch:Pango.Stretch
+    stretch_set:boolean
+    strikethrough:boolean
+    strikethrough_rgba:Gdk.RGBA
+    strikethrough_rgba_set:boolean
+    strikethrough_set:boolean
+    style:Pango.Style
+    style_set:boolean
+    tabs:Pango.TabArray
+    tabs_set:boolean
+    underline:Pango.Underline
+    underline_rgba:Gdk.RGBA
+    underline_rgba_set:boolean
+    underline_set:boolean
+    variant:Pango.Variant
+    variant_set:boolean
+    weight:number
+    weight_set:boolean
+    wrap_mode:Gtk.WrapMode
+    wrap_mode_set:boolean
+    /* Fields of GtkSource.Tag */
+    parent_instance:Gtk.TextTag
+    /* Fields of Gtk.TextTag */
+    priv:Gtk.TextTagPrivate
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Gtk.TextTag */
+    changed(size_changed: boolean): void
+    event(event_object: GObject.Object, event: Gdk.Event, iter: Gtk.TextIter): boolean
+    get_priority(): number
+    set_priority(priority: number): void
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of Gtk.TextTag */
+    vfunc_event(event_object: GObject.Object, event: Gdk.Event, iter: Gtk.TextIter): boolean
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of Gtk.TextTag */
+    connect(sigName: "event", callback: ((obj: Tag, object: GObject.Object, event: Gdk.Event, iter: Gtk.TextIter) => boolean))
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::draw-spaces", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::draw-spaces-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::accumulative-margin", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::background", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::background-full-height", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::background-full-height-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::background-gdk", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::background-rgba", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::background-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::direction", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::editable", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::editable-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::fallback", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::fallback-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::family", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::family-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::font", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::font-desc", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::font-features", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::font-features-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::foreground", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::foreground-gdk", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::foreground-rgba", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::foreground-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::indent", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::indent-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::invisible", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::invisible-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::justification", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::justification-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::language", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::language-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::left-margin", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::left-margin-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::letter-spacing", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::letter-spacing-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::paragraph-background", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::paragraph-background-gdk", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::paragraph-background-rgba", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::paragraph-background-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::pixels-above-lines", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::pixels-above-lines-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::pixels-below-lines", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::pixels-below-lines-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::pixels-inside-wrap", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::pixels-inside-wrap-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::right-margin", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::right-margin-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::rise", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::rise-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::scale", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::scale-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::size", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::size-points", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::size-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::stretch", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::stretch-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::strikethrough", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::strikethrough-rgba", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::strikethrough-rgba-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::strikethrough-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::style", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::style-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::tabs", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::tabs-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::underline", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::underline-rgba", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::underline-rgba-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::underline-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::variant", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::variant-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::weight", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::weight-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::wrap-mode", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::wrap-mode-set", callback: ((obj: Tag, pspec: GObject.ParamSpec) => void))
+}
+export interface Tag_Static {
+    name: string
+    new (config?: Tag_ConstructProps): Tag
+}
+export declare class Tag_Static {
+    new(name: string | null): Tag
+}
+export declare var Tag: Tag_Static
 export interface View_ConstructProps extends Gtk.TextView_ConstructProps {
     auto_indent?:boolean
     background_pattern?:BackgroundPatternType
@@ -5073,6 +5471,7 @@ export interface View {
     show_right_margin:boolean
     smart_backspace:boolean
     smart_home_end:SmartHomeEndType
+    readonly space_drawer:SpaceDrawer
     tab_width:number
     /* Properties of Gtk.TextView */
     accepts_tab:boolean
@@ -5108,6 +5507,7 @@ export interface View {
     double_buffered:boolean
     events:Gdk.EventMask
     expand:boolean
+    focus_on_click:boolean
     halign:Gtk.Align
     has_default:boolean
     has_focus:boolean
@@ -5166,6 +5566,7 @@ export interface View {
     get_show_right_margin(): boolean
     get_smart_backspace(): boolean
     get_smart_home_end(): SmartHomeEndType
+    get_space_drawer(): SpaceDrawer
     get_tab_width(): number
     get_visual_column(iter: Gtk.TextIter): number
     indent_lines(start: Gtk.TextIter, end: Gtk.TextIter): void
@@ -5205,8 +5606,8 @@ export interface View {
     get_indent(): number
     get_input_hints(): Gtk.InputHints
     get_input_purpose(): Gtk.InputPurpose
-    get_iter_at_location(x: number, y: number): /* iter */ Gtk.TextIter
-    get_iter_at_position(x: number, y: number): [ /* iter */ Gtk.TextIter, /* trailing */ number | null ]
+    get_iter_at_location(x: number, y: number): [ /* returnType */ boolean, /* iter */ Gtk.TextIter ]
+    get_iter_at_position(x: number, y: number): [ /* returnType */ boolean, /* iter */ Gtk.TextIter, /* trailing */ number | null ]
     get_iter_location(iter: Gtk.TextIter): /* location */ Gdk.Rectangle
     get_justification(): Gtk.Justification
     get_left_margin(): number
@@ -5218,7 +5619,7 @@ export interface View {
     get_pixels_below_lines(): number
     get_pixels_inside_wrap(): number
     get_right_margin(): number
-    get_tabs(): Pango.TabArray
+    get_tabs(): Pango.TabArray | null
     get_top_margin(): number
     get_vadjustment(): Gtk.Adjustment
     get_visible_rect(): /* visible_rect */ Gdk.Rectangle
@@ -5229,6 +5630,7 @@ export interface View {
     move_mark_onscreen(mark: Gtk.TextMark): boolean
     move_visually(iter: Gtk.TextIter, count: number): boolean
     place_cursor_onscreen(): boolean
+    reset_cursor_blink(): void
     reset_im_context(): void
     scroll_mark_onscreen(mark: Gtk.TextMark): void
     scroll_to_iter(iter: Gtk.TextIter, within_margin: number, use_align: boolean, xalign: number, yalign: number): boolean
@@ -5262,14 +5664,14 @@ export interface View {
     child_notify_by_pspec(child: Gtk.Widget, pspec: GObject.ParamSpec): void
     child_set_property(child: Gtk.Widget, property_name: string, value: any): void
     child_type(): number
-    forall(callback: Gtk.Callback, callback_data: object): void
-    foreach(callback: Gtk.Callback, callback_data: object): void
+    forall(callback: Gtk.Callback, callback_data: object | null): void
+    foreach(callback: Gtk.Callback, callback_data: object | null): void
     get_border_width(): number
     get_children(): GLib.List
     get_focus_chain(): [ /* returnType */ boolean, /* focusable_widgets */ GLib.List ]
-    get_focus_child(): Gtk.Widget
-    get_focus_hadjustment(): Gtk.Adjustment
-    get_focus_vadjustment(): Gtk.Adjustment
+    get_focus_child(): Gtk.Widget | null
+    get_focus_hadjustment(): Gtk.Adjustment | null
+    get_focus_vadjustment(): Gtk.Adjustment | null
     get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     get_resize_mode(): Gtk.ResizeMode
     propagate_draw(child: Gtk.Widget, cr: cairo.Context): void
@@ -5289,7 +5691,7 @@ export interface View {
     add_device_events(device: Gdk.Device, events: Gdk.EventMask): void
     add_events(events: number): void
     add_mnemonic_label(label: Gtk.Widget): void
-    add_tick_callback(callback: Gtk.TickCallback, user_data: object, notify: GLib.DestroyNotify): number
+    add_tick_callback(callback: Gtk.TickCallback, user_data: object | null, notify: GLib.DestroyNotify): number
     can_activate_accel(signal_id: number): boolean
     child_focus(direction: Gtk.DirectionType): boolean
     child_notify(child_property: string): void
@@ -5307,7 +5709,7 @@ export interface View {
     drag_dest_add_text_targets(): void
     drag_dest_add_uri_targets(): void
     drag_dest_find_target(context: Gdk.DragContext, target_list: Gtk.TargetList | null): Gdk.Atom
-    drag_dest_get_target_list(): Gtk.TargetList
+    drag_dest_get_target_list(): Gtk.TargetList | null
     drag_dest_get_track_motion(): boolean
     drag_dest_set(flags: Gtk.DestDefaults, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_dest_set_proxy(proxy_window: Gdk.Window, protocol: Gdk.DragProtocol, use_coordinates: boolean): void
@@ -5319,7 +5721,7 @@ export interface View {
     drag_source_add_image_targets(): void
     drag_source_add_text_targets(): void
     drag_source_add_uri_targets(): void
-    drag_source_get_target_list(): Gtk.TargetList
+    drag_source_get_target_list(): Gtk.TargetList | null
     drag_source_set(start_button_mask: Gdk.ModifierType, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_source_set_icon_gicon(icon: Gio.Icon): void
     drag_source_set_icon_name(icon_name: string): void
@@ -5337,6 +5739,7 @@ export interface View {
     get_action_group(prefix: string): Gio.ActionGroup | null
     get_allocated_baseline(): number
     get_allocated_height(): number
+    get_allocated_size(): [ /* allocation */ Gtk.Allocation, /* baseline */ number | null ]
     get_allocated_width(): number
     get_allocation(): /* allocation */ Gtk.Allocation
     get_ancestor(widget_type: number): Gtk.Widget | null
@@ -5354,9 +5757,10 @@ export interface View {
     get_display(): Gdk.Display
     get_double_buffered(): boolean
     get_events(): number
+    get_focus_on_click(): boolean
     get_font_map(): Pango.FontMap | null
     get_font_options(): cairo.FontOptions | null
-    get_frame_clock(): Gdk.FrameClock
+    get_frame_clock(): Gdk.FrameClock | null
     get_halign(): Gtk.Align
     get_has_tooltip(): boolean
     get_has_window(): boolean
@@ -5376,7 +5780,7 @@ export interface View {
     get_opacity(): number
     get_pango_context(): Pango.Context
     get_parent(): Gtk.Widget | null
-    get_parent_window(): Gdk.Window
+    get_parent_window(): Gdk.Window | null
     get_path(): Gtk.WidgetPath
     get_pointer(): [ /* x */ number | null, /* y */ number | null ]
     get_preferred_height(): [ /* minimum_height */ number | null, /* natural_height */ number | null ]
@@ -5411,7 +5815,7 @@ export interface View {
     get_vexpand_set(): boolean
     get_visible(): boolean
     get_visual(): Gdk.Visual
-    get_window(): Gdk.Window
+    get_window(): Gdk.Window | null
     grab_add(): void
     grab_default(): void
     grab_focus(): void
@@ -5426,7 +5830,7 @@ export interface View {
     init_template(): void
     input_shape_combine_region(region: cairo.Region | null): void
     insert_action_group(name: string, group: Gio.ActionGroup | null): void
-    intersect(area: Gdk.Rectangle, intersection: Gdk.Rectangle | null): boolean
+    intersect(area: Gdk.Rectangle): [ /* returnType */ boolean, /* intersection */ Gdk.Rectangle | null ]
     is_ancestor(ancestor: Gtk.Widget): boolean
     is_composited(): boolean
     is_drawable(): boolean
@@ -5452,6 +5856,7 @@ export interface View {
     override_font(font_desc: Pango.FontDescription | null): void
     override_symbolic_color(name: string, color: Gdk.RGBA | null): void
     path(): [ /* path_length */ number | null, /* path */ string | null, /* path_reversed */ string | null ]
+    queue_allocate(): void
     queue_compute_expand(): void
     queue_draw(): void
     queue_draw_area(x: number, y: number, width: number, height: number): void
@@ -5464,7 +5869,7 @@ export interface View {
     remove_accelerator(accel_group: Gtk.AccelGroup, accel_key: number, accel_mods: Gdk.ModifierType): boolean
     remove_mnemonic_label(label: Gtk.Widget): void
     remove_tick_callback(id: number): void
-    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf
+    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf | null
     render_icon_pixbuf(stock_id: string, size: number): GdkPixbuf.Pixbuf | null
     reparent(new_parent: Gtk.Widget): void
     reset_rc_styles(): void
@@ -5484,6 +5889,7 @@ export interface View {
     set_direction(dir: Gtk.TextDirection): void
     set_double_buffered(double_buffered: boolean): void
     set_events(events: number): void
+    set_focus_on_click(focus_on_click: boolean): void
     set_font_map(font_map: Pango.FontMap | null): void
     set_font_options(options: cairo.FontOptions | null): void
     set_halign(align: Gtk.Align): void
@@ -5531,7 +5937,7 @@ export interface View {
     style_attach(): void
     style_get_property(property_name: string, value: any): void
     thaw_child_notify(): void
-    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number, /* dest_y */ number ]
+    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number | null, /* dest_y */ number | null ]
     trigger_tooltip_query(): void
     unmap(): void
     unparent(): void
@@ -5543,9 +5949,9 @@ export interface View {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5554,10 +5960,10 @@ export interface View {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5586,7 +5992,7 @@ export interface View {
     vfunc_check_resize(): void
     vfunc_child_type(): number
     vfunc_composite_name(child: Gtk.Widget): string
-    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object): void
+    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object | null): void
     vfunc_get_child_property(child: Gtk.Widget, property_id: number, value: any, pspec: GObject.ParamSpec): void
     vfunc_get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     vfunc_remove(widget: Gtk.Widget): void
@@ -5756,7 +6162,7 @@ export interface View {
     connect(sigName: "leave-notify-event", callback: ((obj: View, event: Gdk.EventCrossing) => boolean))
     connect(sigName: "map", callback: ((obj: View) => void))
     connect(sigName: "map-event", callback: ((obj: View, event: Gdk.EventAny) => boolean))
-    connect(sigName: "mnemonic-activate", callback: ((obj: View, arg1: boolean) => boolean))
+    connect(sigName: "mnemonic-activate", callback: ((obj: View, group_cycling: boolean) => boolean))
     connect(sigName: "motion-notify-event", callback: ((obj: View, event: Gdk.EventMotion) => boolean))
     connect(sigName: "move-focus", callback: ((obj: View, direction: Gtk.DirectionType) => void))
     connect(sigName: "parent-set", callback: ((obj: View, old_parent: Gtk.Widget | null) => void))
@@ -5802,6 +6208,7 @@ export interface View {
     connect(sigName: "notify::show-right-margin", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::smart-backspace", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::smart-home-end", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::space-drawer", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::tab-width", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::accepts-tab", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::bottom-margin", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
@@ -5834,6 +6241,7 @@ export interface View {
     connect(sigName: "notify::double-buffered", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::events", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::expand", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::focus-on-click", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::halign", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-default", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-focus", callback: ((obj: View, pspec: GObject.ParamSpec) => void))
@@ -6002,6 +6410,17 @@ export interface PrintCompositorPrivate_Static {
     name: string
 }
 export declare var PrintCompositorPrivate: PrintCompositorPrivate_Static
+export interface RegionIter {
+    /* Fields of GtkSource.RegionIter */
+    /* Methods of GtkSource.RegionIter */
+    get_subregion(): [ /* returnType */ boolean, /* start */ Gtk.TextIter | null, /* end */ Gtk.TextIter | null ]
+    is_end(): boolean
+    next(): boolean
+}
+export interface RegionIter_Static {
+    name: string
+}
+export declare var RegionIter: RegionIter_Static
 export interface SearchContextPrivate {
 }
 export interface SearchContextPrivate_Static {
@@ -6014,6 +6433,12 @@ export interface SearchSettingsPrivate_Static {
     name: string
 }
 export declare var SearchSettingsPrivate: SearchSettingsPrivate_Static
+export interface SpaceDrawerPrivate {
+}
+export interface SpaceDrawerPrivate_Static {
+    name: string
+}
+export declare var SpaceDrawerPrivate: SpaceDrawerPrivate_Static
 export interface StyleSchemeManagerPrivate {
 }
 export interface StyleSchemeManagerPrivate_Static {

--- a/out/Notify.d.ts
+++ b/out/Notify.d.ts
@@ -26,7 +26,7 @@ export function is_initted(): boolean
 export function set_app_name(app_name: string): void
 export function uninit(): void
 export interface ActionCallback {
-    (notification: Notification, action: string, user_data: object): void
+    (notification: Notification, action: string, user_data: object | null): void
 }
 export interface Notification_ConstructProps extends GObject.Object_ConstructProps {
     app_name?:string
@@ -47,7 +47,7 @@ export interface Notification {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Notify.Notification */
-    add_action(action: string, label: string, callback: ActionCallback, user_data: object, free_func: GLib.DestroyNotify): void
+    add_action(action: string, label: string, callback: ActionCallback, user_data: object | null, free_func: GLib.DestroyNotify): void
     clear_actions(): void
     clear_hints(): void
     close(): boolean
@@ -56,7 +56,7 @@ export interface Notification {
     set_category(category: string): void
     set_hint(key: string, value: GLib.Variant | null): void
     set_hint_byte(key: string, value: number): void
-    set_hint_byte_array(key: string, value: number, len: number): void
+    set_hint_byte_array(key: string, value: Gjs.byteArray.ByteArray): void
     set_hint_double(key: string, value: number): void
     set_hint_int32(key: string, value: number): void
     set_hint_string(key: string, value: string): void
@@ -72,9 +72,9 @@ export interface Notification {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -83,10 +83,10 @@ export interface Notification {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void

--- a/out/Pango.d.ts
+++ b/out/Pango.d.ts
@@ -189,6 +189,35 @@ export enum Script {
     SHARADA,
     SORA_SOMPENG,
     TAKRI,
+    BASSA_VAH,
+    CAUCASIAN_ALBANIAN,
+    DUPLOYAN,
+    ELBASAN,
+    GRANTHA,
+    KHOJKI,
+    KHUDAWADI,
+    LINEAR_A,
+    MAHAJANI,
+    MANICHAEAN,
+    MENDE_KIKAKUI,
+    MODI,
+    MRO,
+    NABATAEAN,
+    OLD_NORTH_ARABIAN,
+    OLD_PERMIC,
+    PAHAWH_HMONG,
+    PALMYRENE,
+    PAU_CIN_HAU,
+    PSALTER_PAHLAVI,
+    SIDDHAM,
+    TIRHUTA,
+    WARANG_CITI,
+    AHOM,
+    ANATOLIAN_HIEROGLYPHS,
+    HATRAN,
+    MULTANI,
+    OLD_HUNGARIAN,
+    SIGNWRITING,
 }
 export enum Stretch {
     ULTRA_CONDENSED,
@@ -260,6 +289,7 @@ export const RENDER_TYPE_NONE:string
 export const SCALE:number
 export const UNKNOWN_GLYPH_HEIGHT:number
 export const UNKNOWN_GLYPH_WIDTH:number
+export const VERSION_MIN_REQUIRED:number
 export function attr_type_get_name(type: AttrType): string | null
 export function attr_type_register(name: string): AttrType
 export function bidi_type_for_unichar(ch: number): BidiType
@@ -296,7 +326,7 @@ export function parse_style(str: string, warn: boolean): [ /* returnType */ bool
 export function parse_variant(str: string, warn: boolean): [ /* returnType */ boolean, /* variant */ Variant ]
 export function parse_weight(str: string, warn: boolean): [ /* returnType */ boolean, /* weight */ Weight ]
 export function quantize_line_geometry(thickness: number, position: number): void
-export function read_line(stream: object): [ /* returnType */ number, /* str */ GLib.String ]
+export function read_line(stream: object | null): [ /* returnType */ number, /* str */ GLib.String ]
 export function reorder_items(logical_items: GLib.List): GLib.List
 export function scan_int(pos: string): [ /* returnType */ boolean, /* out */ number ]
 export function scan_string(pos: string): [ /* returnType */ boolean, /* out */ GLib.String ]
@@ -314,11 +344,14 @@ export function units_to_double(i: number): number
 export function version(): number
 export function version_check(required_major: number, required_minor: number, required_micro: number): string | null
 export function version_string(): string
+export interface AttrDataCopyFunc {
+    (user_data: object | null): object | null
+}
 export interface AttrFilterFunc {
-    (attribute: Attribute, user_data: object): boolean
+    (attribute: Attribute, user_data: object | null): boolean
 }
 export interface FontsetForeachFunc {
-    (fontset: Fontset, font: Font, user_data: object): boolean
+    (fontset: Fontset, font: Font, user_data: object | null): boolean
 }
 export interface Context_ConstructProps extends GObject.Object_ConstructProps {
 }
@@ -352,9 +385,9 @@ export interface Context {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -363,10 +396,10 @@ export interface Context {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -400,9 +433,9 @@ export interface Engine {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -411,10 +444,10 @@ export interface Engine {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -446,9 +479,9 @@ export interface EngineLang {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -457,10 +490,10 @@ export interface EngineLang {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -495,9 +528,9 @@ export interface EngineShape {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -506,10 +539,10 @@ export interface EngineShape {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -542,6 +575,7 @@ export interface Font {
     /* Methods of Pango.Font */
     describe(): FontDescription
     describe_with_absolute_size(): FontDescription
+    find_shaper(language: Language, ch: number): EngineShape
     get_font_map(): FontMap | null
     get_glyph_extents(glyph: Glyph): [ /* ink_rect */ Rectangle | null, /* logical_rect */ Rectangle | null ]
     get_metrics(language: Language | null): FontMetrics
@@ -550,9 +584,9 @@ export interface Font {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -561,16 +595,17 @@ export interface Font {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Pango.Font */
     vfunc_describe(): FontDescription
     vfunc_describe_absolute(): FontDescription
+    vfunc_find_shaper(lang: Language, ch: number): EngineShape
     vfunc_get_font_map(): FontMap | null
     vfunc_get_glyph_extents(glyph: Glyph): [ /* ink_rect */ Rectangle | null, /* logical_rect */ Rectangle | null ]
     vfunc_get_metrics(language: Language | null): FontMetrics
@@ -610,9 +645,9 @@ export interface FontFace {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -621,10 +656,10 @@ export interface FontFace {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -665,9 +700,9 @@ export interface FontFamily {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -676,10 +711,10 @@ export interface FontFamily {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -723,9 +758,9 @@ export interface FontMap {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -734,10 +769,10 @@ export interface FontMap {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -771,7 +806,7 @@ export interface Fontset {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Pango.Fontset */
-    foreach(func: FontsetForeachFunc, data: object): void
+    foreach(func: FontsetForeachFunc, data: object | null): void
     get_font(wc: number): Font
     get_metrics(): FontMetrics
     /* Methods of GObject.Object */
@@ -779,9 +814,9 @@ export interface Fontset {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -790,15 +825,15 @@ export interface Fontset {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Pango.Fontset */
-    vfunc_foreach(func: FontsetForeachFunc, data: object): void
+    vfunc_foreach(func: FontsetForeachFunc, data: object | null): void
     vfunc_get_font(wc: number): Font
     vfunc_get_language(): Language
     vfunc_get_metrics(): FontMetrics
@@ -829,7 +864,7 @@ export interface FontsetSimple {
     append(font: Font): void
     size(): number
     /* Methods of Pango.Fontset */
-    foreach(func: FontsetForeachFunc, data: object): void
+    foreach(func: FontsetForeachFunc, data: object | null): void
     get_font(wc: number): Font
     get_metrics(): FontMetrics
     /* Methods of GObject.Object */
@@ -837,9 +872,9 @@ export interface FontsetSimple {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -848,15 +883,15 @@ export interface FontsetSimple {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Pango.Fontset */
-    vfunc_foreach(func: FontsetForeachFunc, data: object): void
+    vfunc_foreach(func: FontsetForeachFunc, data: object | null): void
     vfunc_get_font(wc: number): Font
     vfunc_get_language(): Language
     vfunc_get_metrics(): FontMetrics
@@ -946,9 +981,9 @@ export interface Layout {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -957,10 +992,10 @@ export interface Layout {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1015,9 +1050,9 @@ export interface Renderer {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1026,10 +1061,10 @@ export interface Renderer {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1157,7 +1192,7 @@ export interface AttrList {
     /* Methods of Pango.AttrList */
     change(attr: Attribute): void
     copy(): AttrList | null
-    filter(func: AttrFilterFunc, data: object): AttrList | null
+    filter(func: AttrFilterFunc, data: object | null): AttrList | null
     insert(attr: Attribute): void
     insert_before(attr: Attribute): void
     ref(): AttrList
@@ -1178,6 +1213,7 @@ export interface AttrShape {
     ink_rect:Rectangle
     logical_rect:Rectangle
     data:object
+    copy_func:AttrDataCopyFunc
     destroy_func:GLib.DestroyNotify
 }
 export interface AttrShape_Static {
@@ -1587,15 +1623,6 @@ export interface RendererPrivate_Static {
     name: string
 }
 export declare var RendererPrivate: RendererPrivate_Static
-export interface ScriptForLang {
-    /* Fields of Pango.ScriptForLang */
-    lang:number[]
-    scripts:Script[]
-}
-export interface ScriptForLang_Static {
-    name: string
-}
-export declare var ScriptForLang: ScriptForLang_Static
 export interface ScriptIter {
     /* Methods of Pango.ScriptIter */
     free(): void

--- a/out/Soup.d.ts
+++ b/out/Soup.d.ts
@@ -299,6 +299,7 @@ export enum MessageFlags {
     NEW_CONNECTION,
     IDEMPOTENT,
     IGNORE_CONNECTION_LIMITS,
+    DO_NOT_USE_AUTH_CACHE,
 }
 export enum ServerListenOptions {
     HTTPS,
@@ -360,6 +361,9 @@ export const FORM_MIME_TYPE_MULTIPART:string
 export const FORM_MIME_TYPE_URLENCODED:string
 export const HEADERS_H:number
 export const LOGGER_H:number
+export const LOGGER_LEVEL:string
+export const LOGGER_MAX_BODY_SIZE:string
+export const MAJOR_VERSION:number
 export const MESSAGE_BODY_H:number
 export const MESSAGE_FIRST_PARTY:string
 export const MESSAGE_FLAGS:string
@@ -381,6 +385,8 @@ export const MESSAGE_TLS_CERTIFICATE:string
 export const MESSAGE_TLS_ERRORS:string
 export const MESSAGE_URI:string
 export const METHOD_H:number
+export const MICRO_VERSION:number
+export const MINOR_VERSION:number
 export const MISC_H:number
 export const MULTIPART_H:number
 export const MULTIPART_INPUT_STREAM_H:number
@@ -447,8 +453,10 @@ export const STATUS_H:number
 export const TYPES_H:number
 export const URI_H:number
 export const VALUE_UTILS_H:number
+export const VERSION_MIN_REQUIRED:number
 export const XMLRPC_H:number
 export const XMLRPC_OLD_H:number
+export function check_version(major: number, minor: number, micro: number): boolean
 export function cookie_parse(header: string, origin: URI): Cookie | null
 export function cookies_from_request(msg: Message): GLib.SList
 export function cookies_from_response(msg: Message): GLib.SList
@@ -462,6 +470,9 @@ export function form_encode_hash(form_data_set: GLib.HashTable): string
 export function form_request_new_from_datalist(method: string, uri: string, form_data_set: GLib.Data): Message
 export function form_request_new_from_hash(method: string, uri: string, form_data_set: GLib.HashTable): Message
 export function form_request_new_from_multipart(uri: string, multipart: Multipart): Message
+export function get_major_version(): number
+export function get_micro_version(): number
+export function get_minor_version(): number
 export function header_contains(header: string, token: string): boolean
 export function header_free_param_list(param_list: GLib.HashTable): void
 export function header_g_string_append_param(string: GLib.String, name: string, value: string): void
@@ -480,8 +491,8 @@ export function request_error_quark(): GLib.Quark
 export function requester_error_quark(): GLib.Quark
 export function status_get_phrase(status_code: number): string
 export function status_proxify(status_code: number): number
-export function str_case_equal(v1: object, v2: object): boolean
-export function str_case_hash(key: object): number
+export function str_case_equal(v1: object | null, v2: object | null): boolean
+export function str_case_hash(key: object | null): number
 export function tld_domain_is_public_suffix(domain: string): boolean
 export function tld_error_quark(): GLib.Quark
 export function tld_get_base_domain(hostname: string): string
@@ -511,56 +522,56 @@ export function xmlrpc_parse_response(method_response: string, length: number, s
 export function xmlrpc_variant_get_datetime(variant: GLib.Variant): Date
 export function xmlrpc_variant_new_datetime(date: Date): GLib.Variant
 export interface AddressCallback {
-    (addr: Address, status: number, user_data: object): void
+    (addr: Address, status: number, user_data: object | null): void
 }
 export interface AuthDomainBasicAuthCallback {
-    (domain: AuthDomain, msg: Message, username: string, password: string, user_data: object): boolean
+    (domain: AuthDomain, msg: Message, username: string, password: string, user_data: object | null): boolean
 }
 export interface AuthDomainDigestAuthCallback {
-    (domain: AuthDomain, msg: Message, username: string, user_data: object): string | null
+    (domain: AuthDomain, msg: Message, username: string, user_data: object | null): string | null
 }
 export interface AuthDomainFilter {
-    (domain: AuthDomain, msg: Message, user_data: object): boolean
+    (domain: AuthDomain, msg: Message, user_data: object | null): boolean
 }
 export interface AuthDomainGenericAuthCallback {
-    (domain: AuthDomain, msg: Message, username: string, user_data: object): boolean
+    (domain: AuthDomain, msg: Message, username: string, user_data: object | null): boolean
 }
 export interface ChunkAllocator {
-    (msg: Message, max_len: number, user_data: object): Buffer | null
+    (msg: Message, max_len: number, user_data: object | null): Buffer | null
 }
 export interface LoggerFilter {
-    (logger: Logger, msg: Message, user_data: object): LoggerLogLevel
+    (logger: Logger, msg: Message, user_data: object | null): LoggerLogLevel
 }
 export interface LoggerPrinter {
-    (logger: Logger, level: LoggerLogLevel, direction: number, data: string, user_data: object): void
+    (logger: Logger, level: LoggerLogLevel, direction: number, data: string, user_data: object | null): void
 }
 export interface MessageHeadersForeachFunc {
-    (name: string, value: string, user_data: object): void
+    (name: string, value: string, user_data: object | null): void
 }
 export interface PasswordManagerCallback {
-    (password_manager: PasswordManager, msg: Message, auth: Auth, retrying: boolean, user_data: object): void
+    (password_manager: PasswordManager, msg: Message, auth: Auth, retrying: boolean, user_data: object | null): void
 }
 export interface ProxyURIResolverCallback {
-    (resolver: ProxyURIResolver, status: number, proxy_uri: URI, user_data: object): void
+    (resolver: ProxyURIResolver, status: number, proxy_uri: URI, user_data: object | null): void
 }
 export interface ServerCallback {
-    (server: Server, msg: Message, path: string, query: GLib.HashTable | null, client: ClientContext, user_data: object): void
+    (server: Server, msg: Message, path: string, query: GLib.HashTable | null, client: ClientContext, user_data: object | null): void
 }
 export interface ServerWebsocketCallback {
-    (server: Server, connection: WebsocketConnection, path: string, client: ClientContext, user_data: object): void
+    (server: Server, connection: WebsocketConnection, path: string, client: ClientContext, user_data: object | null): void
 }
 export interface SessionCallback {
-    (session: Session, msg: Message, user_data: object): void
+    (session: Session, msg: Message, user_data: object | null): void
 }
 export interface SocketCallback {
-    (sock: Socket, status: number, user_data: object): void
+    (sock: Socket, status: number, user_data: object | null): void
 }
 export interface PasswordManager {
     /* Methods of Soup.PasswordManager */
-    get_passwords_async(msg: Message, auth: Auth, retrying: boolean, async_context: GLib.MainContext, cancellable: Gio.Cancellable | null, callback: PasswordManagerCallback, user_data: object): void
+    get_passwords_async(msg: Message, auth: Auth, retrying: boolean, async_context: GLib.MainContext, cancellable: Gio.Cancellable | null, callback: PasswordManagerCallback, user_data: object | null): void
     get_passwords_sync(msg: Message, auth: Auth, cancellable: Gio.Cancellable | null): void
     /* Virtual methods of Soup.PasswordManager */
-    vfunc_get_passwords_async(msg: Message, auth: Auth, retrying: boolean, async_context: GLib.MainContext, cancellable: Gio.Cancellable | null, callback: PasswordManagerCallback, user_data: object): void
+    vfunc_get_passwords_async(msg: Message, auth: Auth, retrying: boolean, async_context: GLib.MainContext, cancellable: Gio.Cancellable | null, callback: PasswordManagerCallback, user_data: object | null): void
     vfunc_get_passwords_sync(msg: Message, auth: Auth, cancellable: Gio.Cancellable | null): void
 }
 export interface PasswordManager_Static {
@@ -569,10 +580,10 @@ export interface PasswordManager_Static {
 export declare var PasswordManager: PasswordManager_Static
 export interface ProxyURIResolver {
     /* Methods of Soup.ProxyURIResolver */
-    get_proxy_uri_async(uri: URI, async_context: GLib.MainContext | null, cancellable: Gio.Cancellable | null, callback: ProxyURIResolverCallback, user_data: object): void
+    get_proxy_uri_async(uri: URI, async_context: GLib.MainContext | null, cancellable: Gio.Cancellable | null, callback: ProxyURIResolverCallback, user_data: object | null): void
     get_proxy_uri_sync(uri: URI, cancellable: Gio.Cancellable | null): [ /* returnType */ number, /* proxy_uri */ URI ]
     /* Virtual methods of Soup.ProxyURIResolver */
-    vfunc_get_proxy_uri_async(uri: URI, async_context: GLib.MainContext | null, cancellable: Gio.Cancellable | null, callback: ProxyURIResolverCallback, user_data: object): void
+    vfunc_get_proxy_uri_async(uri: URI, async_context: GLib.MainContext | null, cancellable: Gio.Cancellable | null, callback: ProxyURIResolverCallback, user_data: object | null): void
     vfunc_get_proxy_uri_sync(uri: URI, cancellable: Gio.Cancellable | null): [ /* returnType */ number, /* proxy_uri */ URI ]
 }
 export interface ProxyURIResolver_Static {
@@ -625,16 +636,16 @@ export interface Address {
     hash_by_ip(): number
     hash_by_name(): number
     is_resolved(): boolean
-    resolve_async(async_context: GLib.MainContext | null, cancellable: Gio.Cancellable | null, callback: AddressCallback, user_data: object): void
+    resolve_async(async_context: GLib.MainContext | null, cancellable: Gio.Cancellable | null, callback: AddressCallback, user_data: object | null): void
     resolve_sync(cancellable: Gio.Cancellable | null): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -643,10 +654,10 @@ export interface Address {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -669,7 +680,7 @@ export interface Address_Static {
 export declare class Address_Static {
     new(name: string, port: number): Address
     new_any(family: AddressFamily, port: number): Address | null
-    new_from_sockaddr(sa: object, len: number): Address | null
+    new_from_sockaddr(sa: object | null, len: number): Address | null
 }
 export declare var Address: Address_Static
 export interface Auth_ConstructProps extends GObject.Object_ConstructProps {
@@ -690,6 +701,7 @@ export interface Auth {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.Auth */
     authenticate(username: string, password: string): void
+    can_authenticate(): boolean
     get_authorization(msg: Message): string
     get_host(): string
     get_info(): string
@@ -707,9 +719,9 @@ export interface Auth {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -718,15 +730,16 @@ export interface Auth {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Soup.Auth */
     vfunc_authenticate(username: string, password: string): void
+    vfunc_can_authenticate(): boolean
     vfunc_get_authorization(msg: Message): string
     vfunc_get_protection_space(source_uri: URI): GLib.SList
     vfunc_is_authenticated(): boolean
@@ -771,6 +784,7 @@ export interface AuthBasic {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.Auth */
     authenticate(username: string, password: string): void
+    can_authenticate(): boolean
     get_authorization(msg: Message): string
     get_host(): string
     get_info(): string
@@ -788,9 +802,9 @@ export interface AuthBasic {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -799,15 +813,16 @@ export interface AuthBasic {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Soup.Auth */
     vfunc_authenticate(username: string, password: string): void
+    vfunc_can_authenticate(): boolean
     vfunc_get_authorization(msg: Message): string
     vfunc_get_protection_space(source_uri: URI): GLib.SList
     vfunc_is_authenticated(): boolean
@@ -849,6 +864,7 @@ export interface AuthDigest {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.Auth */
     authenticate(username: string, password: string): void
+    can_authenticate(): boolean
     get_authorization(msg: Message): string
     get_host(): string
     get_info(): string
@@ -866,9 +882,9 @@ export interface AuthDigest {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -877,15 +893,16 @@ export interface AuthDigest {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Soup.Auth */
     vfunc_authenticate(username: string, password: string): void
+    vfunc_can_authenticate(): boolean
     vfunc_get_authorization(msg: Message): string
     vfunc_get_protection_space(source_uri: URI): GLib.SList
     vfunc_is_authenticated(): boolean
@@ -936,23 +953,23 @@ export interface AuthDomain {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.AuthDomain */
     accepts(msg: Message): string | null
-    basic_set_auth_callback(callback: AuthDomainBasicAuthCallback, user_data: object, dnotify: GLib.DestroyNotify): void
+    basic_set_auth_callback(callback: AuthDomainBasicAuthCallback, user_data: object | null, dnotify: GLib.DestroyNotify): void
     challenge(msg: Message): void
     check_password(msg: Message, username: string, password: string): boolean
     covers(msg: Message): boolean
-    digest_set_auth_callback(callback: AuthDomainDigestAuthCallback, user_data: object, dnotify: GLib.DestroyNotify): void
+    digest_set_auth_callback(callback: AuthDomainDigestAuthCallback, user_data: object | null, dnotify: GLib.DestroyNotify): void
     get_realm(): string
-    set_filter(filter: AuthDomainFilter, filter_data: object, dnotify: GLib.DestroyNotify): void
-    set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: object, dnotify: GLib.DestroyNotify): void
+    set_filter(filter: AuthDomainFilter, filter_data: object | null, dnotify: GLib.DestroyNotify): void
+    set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: object | null, dnotify: GLib.DestroyNotify): void
     try_generic_auth_callback(msg: Message, username: string): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -961,10 +978,10 @@ export interface AuthDomain {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1016,23 +1033,23 @@ export interface AuthDomainBasic {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.AuthDomain */
     accepts(msg: Message): string | null
-    basic_set_auth_callback(callback: AuthDomainBasicAuthCallback, user_data: object, dnotify: GLib.DestroyNotify): void
+    basic_set_auth_callback(callback: AuthDomainBasicAuthCallback, user_data: object | null, dnotify: GLib.DestroyNotify): void
     challenge(msg: Message): void
     check_password(msg: Message, username: string, password: string): boolean
     covers(msg: Message): boolean
-    digest_set_auth_callback(callback: AuthDomainDigestAuthCallback, user_data: object, dnotify: GLib.DestroyNotify): void
+    digest_set_auth_callback(callback: AuthDomainDigestAuthCallback, user_data: object | null, dnotify: GLib.DestroyNotify): void
     get_realm(): string
-    set_filter(filter: AuthDomainFilter, filter_data: object, dnotify: GLib.DestroyNotify): void
-    set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: object, dnotify: GLib.DestroyNotify): void
+    set_filter(filter: AuthDomainFilter, filter_data: object | null, dnotify: GLib.DestroyNotify): void
+    set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: object | null, dnotify: GLib.DestroyNotify): void
     try_generic_auth_callback(msg: Message, username: string): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1041,10 +1058,10 @@ export interface AuthDomainBasic {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1098,23 +1115,23 @@ export interface AuthDomainDigest {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.AuthDomain */
     accepts(msg: Message): string | null
-    basic_set_auth_callback(callback: AuthDomainBasicAuthCallback, user_data: object, dnotify: GLib.DestroyNotify): void
+    basic_set_auth_callback(callback: AuthDomainBasicAuthCallback, user_data: object | null, dnotify: GLib.DestroyNotify): void
     challenge(msg: Message): void
     check_password(msg: Message, username: string, password: string): boolean
     covers(msg: Message): boolean
-    digest_set_auth_callback(callback: AuthDomainDigestAuthCallback, user_data: object, dnotify: GLib.DestroyNotify): void
+    digest_set_auth_callback(callback: AuthDomainDigestAuthCallback, user_data: object | null, dnotify: GLib.DestroyNotify): void
     get_realm(): string
-    set_filter(filter: AuthDomainFilter, filter_data: object, dnotify: GLib.DestroyNotify): void
-    set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: object, dnotify: GLib.DestroyNotify): void
+    set_filter(filter: AuthDomainFilter, filter_data: object | null, dnotify: GLib.DestroyNotify): void
+    set_generic_auth_callback(auth_callback: AuthDomainGenericAuthCallback, auth_data: object | null, dnotify: GLib.DestroyNotify): void
     try_generic_auth_callback(msg: Message, username: string): boolean
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1123,10 +1140,10 @@ export interface AuthDomainDigest {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1170,15 +1187,16 @@ export interface AuthManager {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.AuthManager */
+    clear_cached_credentials(): void
     use_auth(uri: URI, auth: Auth): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1187,10 +1205,10 @@ export interface AuthManager {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1229,6 +1247,7 @@ export interface AuthNTLM {
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.Auth */
     authenticate(username: string, password: string): void
+    can_authenticate(): boolean
     get_authorization(msg: Message): string
     get_host(): string
     get_info(): string
@@ -1246,9 +1265,9 @@ export interface AuthNTLM {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1257,15 +1276,16 @@ export interface AuthNTLM {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Soup.Auth */
     vfunc_authenticate(username: string, password: string): void
+    vfunc_can_authenticate(): boolean
     vfunc_get_authorization(msg: Message): string
     vfunc_get_protection_space(source_uri: URI): GLib.SList
     vfunc_is_authenticated(): boolean
@@ -1292,6 +1312,89 @@ export interface AuthNTLM_Static {
     new (config?: AuthNTLM_ConstructProps): AuthNTLM
 }
 export declare var AuthNTLM: AuthNTLM_Static
+export interface AuthNegotiate_ConstructProps extends Auth_ConstructProps {
+}
+export interface AuthNegotiate {
+    /* Properties of Soup.Auth */
+    host:string
+    readonly is_authenticated:boolean
+    is_for_proxy:boolean
+    realm:string
+    readonly scheme_name:string
+    /* Fields of Soup.Auth */
+    parent:GObject.Object
+    /* Fields of GObject.Object */
+    g_type_instance:GObject.TypeInstance
+    /* Methods of Soup.Auth */
+    authenticate(username: string, password: string): void
+    can_authenticate(): boolean
+    get_authorization(msg: Message): string
+    get_host(): string
+    get_info(): string
+    get_protection_space(source_uri: URI): GLib.SList
+    get_realm(): string
+    get_saved_password(user: string): string
+    get_saved_users(): GLib.SList
+    get_scheme_name(): string
+    has_saved_password(username: string, password: string): void
+    is_ready(msg: Message): boolean
+    save_password(username: string, password: string): void
+    update(msg: Message, auth_header: string): boolean
+    /* Methods of GObject.Object */
+    bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
+    bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
+    force_floating(): void
+    freeze_notify(): void
+    get_data(key: string): object | null
+    get_property(property_name: string, value: GObject.Value): void
+    get_qdata(quark: GLib.Quark): object | null
+    is_floating(): boolean
+    notify(property_name: string): void
+    notify_by_pspec(pspec: GObject.ParamSpec): void
+    ref(): GObject.Object
+    ref_sink(): GObject.Object
+    replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
+    run_dispose(): void
+    set_data(key: string, data: object | null): void
+    set_property(property_name: string, value: GObject.Value): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
+    thaw_notify(): void
+    unref(): void
+    watch_closure(closure: GObject.Closure): void
+    /* Virtual methods of Soup.Auth */
+    vfunc_authenticate(username: string, password: string): void
+    vfunc_can_authenticate(): boolean
+    vfunc_get_authorization(msg: Message): string
+    vfunc_get_protection_space(source_uri: URI): GLib.SList
+    vfunc_is_authenticated(): boolean
+    vfunc_is_ready(msg: Message): boolean
+    vfunc_update(msg: Message, auth_header: GLib.HashTable): boolean
+    /* Virtual methods of GObject.Object */
+    vfunc_constructed(): void
+    vfunc_dispatch_properties_changed(n_pspecs: number, pspecs: GObject.ParamSpec): void
+    vfunc_dispose(): void
+    vfunc_finalize(): void
+    vfunc_get_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    vfunc_notify(pspec: GObject.ParamSpec): void
+    vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
+    /* Signals of GObject.Object */
+    connect(sigName: "notify", callback: ((obj: AuthNegotiate, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::host", callback: ((obj: AuthNegotiate, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::is-authenticated", callback: ((obj: AuthNegotiate, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::is-for-proxy", callback: ((obj: AuthNegotiate, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::realm", callback: ((obj: AuthNegotiate, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::scheme-name", callback: ((obj: AuthNegotiate, pspec: GObject.ParamSpec) => void))
+}
+export interface AuthNegotiate_Static {
+    name: string
+    new (config?: AuthNegotiate_ConstructProps): AuthNegotiate
+}
+export declare class AuthNegotiate_Static {
+    supported(): boolean
+}
+export declare var AuthNegotiate: AuthNegotiate_Static
 export interface Cache_ConstructProps extends GObject.Object_ConstructProps {
     cache_dir?:string
     cache_type?:CacheType
@@ -1315,9 +1418,9 @@ export interface Cache {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1326,10 +1429,10 @@ export interface Cache {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1367,9 +1470,9 @@ export interface ContentDecoder {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1378,10 +1481,10 @@ export interface ContentDecoder {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1417,9 +1520,9 @@ export interface ContentSniffer {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1428,10 +1531,10 @@ export interface ContentSniffer {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1486,9 +1589,9 @@ export interface CookieJar {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1497,10 +1600,10 @@ export interface CookieJar {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1560,9 +1663,9 @@ export interface CookieJarDB {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1571,10 +1674,10 @@ export interface CookieJarDB {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1634,9 +1737,9 @@ export interface CookieJarText {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1645,10 +1748,10 @@ export interface CookieJarText {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1679,8 +1782,13 @@ export declare class CookieJarText_Static {
 }
 export declare var CookieJarText: CookieJarText_Static
 export interface Logger_ConstructProps extends GObject.Object_ConstructProps {
+    level?:LoggerLogLevel
+    max_body_size?:number
 }
 export interface Logger {
+    /* Properties of Soup.Logger */
+    level:LoggerLogLevel
+    max_body_size:number
     /* Fields of Soup.Logger */
     parent:GObject.Object
     /* Fields of GObject.Object */
@@ -1688,17 +1796,17 @@ export interface Logger {
     /* Methods of Soup.Logger */
     attach(session: Session): void
     detach(session: Session): void
-    set_printer(printer: LoggerPrinter, printer_data: object, destroy: GLib.DestroyNotify): void
-    set_request_filter(request_filter: LoggerFilter, filter_data: object, destroy: GLib.DestroyNotify): void
-    set_response_filter(response_filter: LoggerFilter, filter_data: object, destroy: GLib.DestroyNotify): void
+    set_printer(printer: LoggerPrinter, printer_data: object | null, destroy: GLib.DestroyNotify): void
+    set_request_filter(request_filter: LoggerFilter, filter_data: object | null, destroy: GLib.DestroyNotify): void
+    set_response_filter(response_filter: LoggerFilter, filter_data: object | null, destroy: GLib.DestroyNotify): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1707,10 +1815,10 @@ export interface Logger {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1724,6 +1832,8 @@ export interface Logger {
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of GObject.Object */
     connect(sigName: "notify", callback: ((obj: Logger, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::level", callback: ((obj: Logger, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::max-body-size", callback: ((obj: Logger, pspec: GObject.ParamSpec) => void))
 }
 export interface Logger_Static {
     name: string
@@ -1786,7 +1896,7 @@ export interface Message {
     got_informational(): void
     is_keepalive(): boolean
     restarted(): void
-    set_chunk_allocator(allocator: ChunkAllocator, user_data: object, destroy_notify: GLib.DestroyNotify): void
+    set_chunk_allocator(allocator: ChunkAllocator, user_data: object | null, destroy_notify: GLib.DestroyNotify): void
     set_first_party(first_party: URI): void
     set_flags(flags: MessageFlags): void
     set_http_version(version: HTTPVersion): void
@@ -1808,9 +1918,9 @@ export interface Message {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1819,10 +1929,10 @@ export interface Message {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1906,7 +2016,7 @@ export interface MultipartInputStream {
     /* Methods of Soup.MultipartInputStream */
     get_headers(): MessageHeaders | null
     next_part(cancellable: Gio.Cancellable | null): Gio.InputStream | null
-    next_part_async(io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, data: object): void
+    next_part_async(io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, data: object | null): void
     next_part_finish(result: Gio.AsyncResult): Gio.InputStream | null
     /* Methods of Gio.FilterInputStream */
     get_base_stream(): Gio.InputStream
@@ -1915,31 +2025,31 @@ export interface MultipartInputStream {
     /* Methods of Gio.InputStream */
     clear_pending(): void
     close(cancellable: Gio.Cancellable | null): boolean
-    close_async(io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    close_async(io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     close_finish(result: Gio.AsyncResult): boolean
     has_pending(): boolean
     is_closed(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Gio.Cancellable | null): number
     read_all(buffer: Gjs.byteArray.ByteArray, cancellable: Gio.Cancellable | null): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    read_all_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     read_all_finish(result: Gio.AsyncResult): [ /* returnType */ boolean, /* bytes_read */ number ]
-    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     read_bytes(count: number, cancellable: Gio.Cancellable | null): Gjs.byteArray.ByteArray
-    read_bytes_async(count: number, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    read_bytes_async(count: number, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     read_bytes_finish(result: Gio.AsyncResult): Gjs.byteArray.ByteArray
     read_finish(result: Gio.AsyncResult): number
     set_pending(): boolean
     skip(count: number, cancellable: Gio.Cancellable | null): number
-    skip_async(count: number, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    skip_async(count: number, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     skip_finish(result: Gio.AsyncResult): number
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1948,22 +2058,22 @@ export interface MultipartInputStream {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
     /* Virtual methods of Gio.InputStream */
-    vfunc_close_async(io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_close_async(io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_close_finish(result: Gio.AsyncResult): boolean
     vfunc_close_fn(cancellable: Gio.Cancellable | null): boolean
-    vfunc_read_async(buffer: Gjs.byteArray.ByteArray, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_read_async(buffer: Gjs.byteArray.ByteArray | null, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_read_finish(result: Gio.AsyncResult): number
-    vfunc_read_fn(buffer: object, count: number, cancellable: Gio.Cancellable | null): number
+    vfunc_read_fn(buffer: object | null, count: number, cancellable: Gio.Cancellable | null): number
     vfunc_skip(count: number, cancellable: Gio.Cancellable | null): number
-    vfunc_skip_async(count: number, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_skip_async(count: number, io_priority: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_skip_finish(result: Gio.AsyncResult): number
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2000,9 +2110,9 @@ export interface ProxyResolverDefault {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2011,10 +2121,10 @@ export interface ProxyResolverDefault {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2052,16 +2162,16 @@ export interface Request {
     get_session(): Session
     get_uri(): URI
     send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2070,10 +2180,10 @@ export interface Request {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2082,7 +2192,7 @@ export interface Request {
     vfunc_get_content_length(): number
     vfunc_get_content_type(): string | null
     vfunc_send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2116,16 +2226,16 @@ export interface RequestData {
     get_session(): Session
     get_uri(): URI
     send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2134,10 +2244,10 @@ export interface RequestData {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2146,7 +2256,7 @@ export interface RequestData {
     vfunc_get_content_length(): number
     vfunc_get_content_type(): string | null
     vfunc_send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2182,16 +2292,16 @@ export interface RequestFile {
     get_session(): Session
     get_uri(): URI
     send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2200,10 +2310,10 @@ export interface RequestFile {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2212,7 +2322,7 @@ export interface RequestFile {
     vfunc_get_content_length(): number
     vfunc_get_content_type(): string | null
     vfunc_send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2248,16 +2358,16 @@ export interface RequestHTTP {
     get_session(): Session
     get_uri(): URI
     send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2266,10 +2376,10 @@ export interface RequestHTTP {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2278,7 +2388,7 @@ export interface RequestHTTP {
     vfunc_get_content_length(): number
     vfunc_get_content_type(): string | null
     vfunc_send(cancellable: Gio.Cancellable | null): Gio.InputStream
-    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    vfunc_send_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     vfunc_send_finish(result: Gio.AsyncResult): Gio.InputStream
     /* Virtual methods of GObject.Object */
     vfunc_constructed(): void
@@ -2312,9 +2422,9 @@ export interface Requester {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2323,10 +2433,10 @@ export interface Requester {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2373,9 +2483,9 @@ export interface Server {
     /* Methods of Soup.Server */
     accept_iostream(stream: Gio.IOStream, local_addr: Gio.SocketAddress | null, remote_addr: Gio.SocketAddress | null): boolean
     add_auth_domain(auth_domain: AuthDomain): void
-    add_early_handler(path: string | null, callback: ServerCallback, user_data: object, destroy: GLib.DestroyNotify): void
-    add_handler(path: string | null, callback: ServerCallback, user_data: object, destroy: GLib.DestroyNotify): void
-    add_websocket_handler(path: string | null, origin: string | null, protocols: string[] | null, callback: ServerWebsocketCallback, user_data: object, destroy: GLib.DestroyNotify): void
+    add_early_handler(path: string | null, callback: ServerCallback, user_data: object | null, destroy: GLib.DestroyNotify): void
+    add_handler(path: string | null, callback: ServerCallback, user_data: object | null, destroy: GLib.DestroyNotify): void
+    add_websocket_handler(path: string | null, origin: string | null, protocols: string[] | null, callback: ServerWebsocketCallback, user_data: object | null, destroy: GLib.DestroyNotify): void
     disconnect(): void
     get_async_context(): GLib.MainContext | null
     get_listener(): Socket
@@ -2401,9 +2511,9 @@ export interface Server {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2412,10 +2522,10 @@ export interface Server {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2505,7 +2615,7 @@ export interface Session {
     get_features(feature_type: number): GLib.SList
     has_feature(feature_type: number): boolean
     pause_message(msg: Message): void
-    prefetch_dns(hostname: string, cancellable: Gio.Cancellable | null, callback: AddressCallback | null, user_data: object): void
+    prefetch_dns(hostname: string, cancellable: Gio.Cancellable | null, callback: AddressCallback | null, user_data: object | null): void
     prepare_for_uri(uri: URI): void
     queue_message(msg: Message, callback: SessionCallback | null, user_data: object | null): void
     redirect_message(msg: Message): boolean
@@ -2517,12 +2627,12 @@ export interface Session {
     request_uri(uri: URI): Request
     requeue_message(msg: Message): void
     send(msg: Message, cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(msg: Message, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(msg: Message, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     send_message(msg: Message): number
     steal_connection(msg: Message): Gio.IOStream
     unpause_message(msg: Message): void
-    websocket_connect_async(msg: Message, origin: string | null, protocols: string[] | null, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    websocket_connect_async(msg: Message, origin: string | null, protocols: string[] | null, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     websocket_connect_finish(result: Gio.AsyncResult): WebsocketConnection
     would_redirect(msg: Message): boolean
     /* Methods of GObject.Object */
@@ -2530,9 +2640,9 @@ export interface Session {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2541,10 +2651,10 @@ export interface Session {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2640,7 +2750,7 @@ export interface SessionAsync {
     get_features(feature_type: number): GLib.SList
     has_feature(feature_type: number): boolean
     pause_message(msg: Message): void
-    prefetch_dns(hostname: string, cancellable: Gio.Cancellable | null, callback: AddressCallback | null, user_data: object): void
+    prefetch_dns(hostname: string, cancellable: Gio.Cancellable | null, callback: AddressCallback | null, user_data: object | null): void
     prepare_for_uri(uri: URI): void
     queue_message(msg: Message, callback: SessionCallback | null, user_data: object | null): void
     redirect_message(msg: Message): boolean
@@ -2652,12 +2762,12 @@ export interface SessionAsync {
     request_uri(uri: URI): Request
     requeue_message(msg: Message): void
     send(msg: Message, cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(msg: Message, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(msg: Message, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     send_message(msg: Message): number
     steal_connection(msg: Message): Gio.IOStream
     unpause_message(msg: Message): void
-    websocket_connect_async(msg: Message, origin: string | null, protocols: string[] | null, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    websocket_connect_async(msg: Message, origin: string | null, protocols: string[] | null, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     websocket_connect_finish(result: Gio.AsyncResult): WebsocketConnection
     would_redirect(msg: Message): boolean
     /* Methods of GObject.Object */
@@ -2665,9 +2775,9 @@ export interface SessionAsync {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2676,10 +2786,10 @@ export interface SessionAsync {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2775,7 +2885,7 @@ export interface SessionSync {
     get_features(feature_type: number): GLib.SList
     has_feature(feature_type: number): boolean
     pause_message(msg: Message): void
-    prefetch_dns(hostname: string, cancellable: Gio.Cancellable | null, callback: AddressCallback | null, user_data: object): void
+    prefetch_dns(hostname: string, cancellable: Gio.Cancellable | null, callback: AddressCallback | null, user_data: object | null): void
     prepare_for_uri(uri: URI): void
     queue_message(msg: Message, callback: SessionCallback | null, user_data: object | null): void
     redirect_message(msg: Message): boolean
@@ -2787,12 +2897,12 @@ export interface SessionSync {
     request_uri(uri: URI): Request
     requeue_message(msg: Message): void
     send(msg: Message, cancellable: Gio.Cancellable | null): Gio.InputStream
-    send_async(msg: Message, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    send_async(msg: Message, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     send_finish(result: Gio.AsyncResult): Gio.InputStream
     send_message(msg: Message): number
     steal_connection(msg: Message): Gio.IOStream
     unpause_message(msg: Message): void
-    websocket_connect_async(msg: Message, origin: string | null, protocols: string[] | null, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    websocket_connect_async(msg: Message, origin: string | null, protocols: string[] | null, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     websocket_connect_finish(result: Gio.AsyncResult): WebsocketConnection
     would_redirect(msg: Message): boolean
     /* Methods of GObject.Object */
@@ -2800,9 +2910,9 @@ export interface SessionSync {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2811,10 +2921,10 @@ export interface SessionSync {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2902,7 +3012,7 @@ export interface Socket {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of Soup.Socket */
-    connect_async(cancellable: Gio.Cancellable | null, callback: SocketCallback, user_data: object): void
+    connect_async(cancellable: Gio.Cancellable | null, callback: SocketCallback, user_data: object | null): void
     connect_sync(cancellable: Gio.Cancellable | null): number
     disconnect(): void
     get_fd(): number
@@ -2912,7 +3022,7 @@ export interface Socket {
     is_ssl(): boolean
     listen(): boolean
     read(buffer: Gjs.byteArray.ByteArray, cancellable: Gio.Cancellable | null): [ /* returnType */ SocketIOStatus, /* nread */ number ]
-    read_until(buffer: Gjs.byteArray.ByteArray, boundary: object, boundary_len: number, got_boundary: boolean, cancellable: Gio.Cancellable | null): [ /* returnType */ SocketIOStatus, /* nread */ number ]
+    read_until(buffer: Gjs.byteArray.ByteArray, boundary: object | null, boundary_len: number, got_boundary: boolean, cancellable: Gio.Cancellable | null): [ /* returnType */ SocketIOStatus, /* nread */ number ]
     start_proxy_ssl(ssl_host: string, cancellable: Gio.Cancellable | null): boolean
     start_ssl(cancellable: Gio.Cancellable | null): boolean
     write(buffer: Gjs.byteArray.ByteArray, cancellable: Gio.Cancellable | null): [ /* returnType */ SocketIOStatus, /* nwrote */ number ]
@@ -2921,9 +3031,9 @@ export interface Socket {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2932,10 +3042,10 @@ export interface Socket {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2977,12 +3087,16 @@ export declare var Socket: Socket_Static
 export interface WebsocketConnection_ConstructProps extends GObject.Object_ConstructProps {
     connection_type?:WebsocketConnectionType
     io_stream?:Gio.IOStream
+    keepalive_interval?:number
+    max_incoming_payload_size?:number
     origin?:string
     protocol?:string
     uri?:URI
 }
 export interface WebsocketConnection {
     /* Properties of Soup.WebsocketConnection */
+    keepalive_interval:number
+    max_incoming_payload_size:number
     readonly state:WebsocketState
     /* Fields of Soup.WebsocketConnection */
     parent:GObject.Object
@@ -2994,20 +3108,24 @@ export interface WebsocketConnection {
     get_close_data(): string
     get_connection_type(): WebsocketConnectionType
     get_io_stream(): Gio.IOStream
+    get_keepalive_interval(): number
+    get_max_incoming_payload_size(): number
     get_origin(): string | null
     get_protocol(): string | null
     get_state(): WebsocketState
     get_uri(): URI
     send_binary(data: Gjs.byteArray.ByteArray): void
     send_text(text: string): void
+    set_keepalive_interval(interval: number): void
+    set_max_incoming_payload_size(max_incoming_payload_size: number): void
     /* Methods of GObject.Object */
     bind_property(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags): GObject.Binding
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3016,10 +3134,10 @@ export interface WebsocketConnection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3043,6 +3161,8 @@ export interface WebsocketConnection {
     connect(sigName: "message", callback: ((obj: WebsocketConnection, type: number, message: Gjs.byteArray.ByteArray) => void))
     /* Signals of GObject.Object */
     connect(sigName: "notify", callback: ((obj: WebsocketConnection, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::keepalive-interval", callback: ((obj: WebsocketConnection, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::max-incoming-payload-size", callback: ((obj: WebsocketConnection, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::state", callback: ((obj: WebsocketConnection, pspec: GObject.ParamSpec) => void))
 }
 export interface WebsocketConnection_Static {
@@ -3068,7 +3188,7 @@ export interface Buffer {
     free(): void
     get_as_bytes(): Gjs.byteArray.ByteArray
     get_data(): /* data */ Gjs.byteArray.ByteArray
-    get_owner(): object
+    get_owner(): object | null
     new_subbuffer(offset: number, length: number): Buffer
 }
 export interface Buffer_Static {
@@ -3076,7 +3196,7 @@ export interface Buffer_Static {
 }
 export declare class Buffer_Static {
     new_take(data: Gjs.byteArray.ByteArray, length: number): Buffer
-    new_with_owner(data: Gjs.byteArray.ByteArray, length: number, owner: object, owner_dnotify: GLib.DestroyNotify | null): Buffer
+    new_with_owner(data: Gjs.byteArray.ByteArray, length: number, owner: object | null, owner_dnotify: GLib.DestroyNotify | null): Buffer
 }
 export declare var Buffer: Buffer_Static
 export interface CachePrivate {
@@ -3228,13 +3348,13 @@ export interface MessageHeaders {
     append(name: string, value: string): void
     clean_connection_headers(): void
     clear(): void
-    foreach(func: MessageHeadersForeachFunc, user_data: object): void
+    foreach(func: MessageHeadersForeachFunc, user_data: object | null): void
     free(): void
     free_ranges(ranges: Range): void
     get(name: string): string | null
     get_content_disposition(): [ /* returnType */ boolean, /* disposition */ string, /* params */ GLib.HashTable ]
     get_content_length(): number
-    get_content_range(start: number, end: number, total_length: number): boolean
+    get_content_range(): [ /* returnType */ boolean, /* start */ number, /* end */ number, /* total_length */ number | null ]
     get_content_type(): [ /* returnType */ string | null, /* params */ GLib.HashTable | null ]
     get_encoding(): Encoding
     get_expectations(): Expectation

--- a/out/WebKit.d.ts
+++ b/out/WebKit.d.ts
@@ -312,9 +312,9 @@ export interface DOMAttr {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -323,10 +323,10 @@ export interface DOMAttr {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -397,9 +397,9 @@ export interface DOMAudioTrack {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -408,10 +408,10 @@ export interface DOMAudioTrack {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -459,9 +459,9 @@ export interface DOMAudioTrackList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -470,10 +470,10 @@ export interface DOMAudioTrackList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -510,9 +510,9 @@ export interface DOMBarInfo {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -521,10 +521,10 @@ export interface DOMBarInfo {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -545,7 +545,7 @@ export interface DOMBarInfo_Static {
     new (config?: DOMBarInfo_ConstructProps): DOMBarInfo
 }
 export declare class DOMBarInfo_Static {
-    get_visible(self: object): boolean
+    get_visible(self: object | null): boolean
 }
 export declare var DOMBarInfo: DOMBarInfo_Static
 export interface DOMBarProp_ConstructProps extends DOMObject_ConstructProps {
@@ -568,9 +568,9 @@ export interface DOMBarProp {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -579,10 +579,10 @@ export interface DOMBarProp {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -630,9 +630,9 @@ export interface DOMBatteryManager {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -641,10 +641,10 @@ export interface DOMBatteryManager {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -691,9 +691,9 @@ export interface DOMBlob {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -702,10 +702,10 @@ export interface DOMBlob {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -821,7 +821,7 @@ export interface DOMCDATASection {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -830,8 +830,8 @@ export interface DOMCDATASection {
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -897,9 +897,9 @@ export interface DOMCSSRule {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -908,10 +908,10 @@ export interface DOMCSSRule {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -956,9 +956,9 @@ export interface DOMCSSRuleList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -967,10 +967,10 @@ export interface DOMCSSRuleList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1025,9 +1025,9 @@ export interface DOMCSSStyleDeclaration {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1036,9 +1036,9 @@ export interface DOMCSSStyleDeclaration {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    set_data(key: string, data: object | null): void
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1106,9 +1106,9 @@ export interface DOMCSSStyleSheet {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1117,10 +1117,10 @@ export interface DOMCSSStyleSheet {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1174,9 +1174,9 @@ export interface DOMCSSValue {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1185,10 +1185,10 @@ export interface DOMCSSValue {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1297,7 +1297,7 @@ export interface DOMCharacterData {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1306,8 +1306,8 @@ export interface DOMCharacterData {
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1432,7 +1432,7 @@ export interface DOMComment {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1441,8 +1441,8 @@ export interface DOMComment {
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1492,7 +1492,7 @@ export interface DOMConsole {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of WebKit.DOMConsole */
-    get_memory(): object
+    get_memory(): object | null
     group_end(): void
     time(title: string): void
     /* Methods of GObject.Object */
@@ -1500,9 +1500,9 @@ export interface DOMConsole {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1511,10 +1511,10 @@ export interface DOMConsole {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1558,9 +1558,9 @@ export interface DOMDOMApplicationCache {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1569,10 +1569,10 @@ export interface DOMDOMApplicationCache {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1615,9 +1615,9 @@ export interface DOMDOMImplementation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1626,10 +1626,10 @@ export interface DOMDOMImplementation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1674,9 +1674,9 @@ export interface DOMDOMMimeType {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1685,10 +1685,10 @@ export interface DOMDOMMimeType {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1734,9 +1734,9 @@ export interface DOMDOMMimeTypeArray {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1745,10 +1745,10 @@ export interface DOMDOMMimeTypeArray {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1791,9 +1791,9 @@ export interface DOMDOMNamedFlowCollection {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1802,10 +1802,10 @@ export interface DOMDOMNamedFlowCollection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1854,9 +1854,9 @@ export interface DOMDOMPlugin {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1865,10 +1865,10 @@ export interface DOMDOMPlugin {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1915,9 +1915,9 @@ export interface DOMDOMPluginArray {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1926,10 +1926,10 @@ export interface DOMDOMPluginArray {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -1988,9 +1988,9 @@ export interface DOMDOMSecurityPolicy {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -1999,10 +1999,10 @@ export interface DOMDOMSecurityPolicy {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2080,9 +2080,9 @@ export interface DOMDOMSelection {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2091,10 +2091,10 @@ export interface DOMDOMSelection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2157,9 +2157,9 @@ export interface DOMDOMSettableTokenList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2168,10 +2168,10 @@ export interface DOMDOMSettableTokenList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2215,9 +2215,9 @@ export interface DOMDOMStringList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2226,10 +2226,10 @@ export interface DOMDOMStringList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2266,9 +2266,9 @@ export interface DOMDOMStringMap {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2277,10 +2277,10 @@ export interface DOMDOMStringMap {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2325,9 +2325,9 @@ export interface DOMDOMTokenList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2336,10 +2336,10 @@ export interface DOMDOMTokenList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2505,9 +2505,9 @@ export interface DOMDOMWindow {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2516,10 +2516,10 @@ export interface DOMDOMWindow {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2602,9 +2602,9 @@ export interface DOMDOMWindowCSS {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2613,10 +2613,10 @@ export interface DOMDOMWindowCSS {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2656,9 +2656,9 @@ export interface DOMDatabase {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2667,10 +2667,10 @@ export interface DOMDatabase {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -2903,9 +2903,9 @@ export interface DOMDocument {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -2914,10 +2914,10 @@ export interface DOMDocument {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3068,9 +3068,9 @@ export interface DOMDocumentFragment {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3079,10 +3079,10 @@ export interface DOMDocumentFragment {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3205,9 +3205,9 @@ export interface DOMDocumentType {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3216,10 +3216,10 @@ export interface DOMDocumentType {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3422,9 +3422,9 @@ export interface DOMElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3433,10 +3433,10 @@ export interface DOMElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3569,9 +3569,9 @@ export interface DOMEntityReference {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3580,10 +3580,10 @@ export interface DOMEntityReference {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3666,9 +3666,9 @@ export interface DOMEvent {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3677,10 +3677,10 @@ export interface DOMEvent {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3741,9 +3741,9 @@ export interface DOMFile {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3752,10 +3752,10 @@ export interface DOMFile {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3800,9 +3800,9 @@ export interface DOMFileList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3811,10 +3811,10 @@ export interface DOMFileList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3859,9 +3859,9 @@ export interface DOMGamepad {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3870,10 +3870,10 @@ export interface DOMGamepad {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3917,9 +3917,9 @@ export interface DOMGamepadList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3928,10 +3928,10 @@ export interface DOMGamepadList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -3970,9 +3970,9 @@ export interface DOMGeolocation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -3981,10 +3981,10 @@ export interface DOMGeolocation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4177,7 +4177,7 @@ export interface DOMHTMLAnchorElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -4305,9 +4305,9 @@ export interface DOMHTMLAnchorElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4316,10 +4316,10 @@ export interface DOMHTMLAnchorElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4557,7 +4557,7 @@ export interface DOMHTMLAppletElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -4685,9 +4685,9 @@ export interface DOMHTMLAppletElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -4696,10 +4696,10 @@ export interface DOMHTMLAppletElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -4925,7 +4925,7 @@ export interface DOMHTMLAreaElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -5053,9 +5053,9 @@ export interface DOMHTMLAreaElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5064,10 +5064,10 @@ export interface DOMHTMLAreaElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5344,7 +5344,7 @@ export interface DOMHTMLAudioElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -5472,9 +5472,9 @@ export interface DOMHTMLAudioElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5483,10 +5483,10 @@ export interface DOMHTMLAudioElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -5696,7 +5696,7 @@ export interface DOMHTMLBRElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -5824,9 +5824,9 @@ export interface DOMHTMLBRElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -5835,10 +5835,10 @@ export interface DOMHTMLBRElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6020,7 +6020,7 @@ export interface DOMHTMLBaseElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -6148,9 +6148,9 @@ export interface DOMHTMLBaseElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6159,10 +6159,10 @@ export interface DOMHTMLBaseElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6349,7 +6349,7 @@ export interface DOMHTMLBaseFontElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -6477,9 +6477,9 @@ export interface DOMHTMLBaseFontElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6488,10 +6488,10 @@ export interface DOMHTMLBaseFontElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -6691,7 +6691,7 @@ export interface DOMHTMLBodyElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -6819,9 +6819,9 @@ export interface DOMHTMLBodyElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -6830,10 +6830,10 @@ export interface DOMHTMLBodyElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7062,7 +7062,7 @@ export interface DOMHTMLButtonElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -7190,9 +7190,9 @@ export interface DOMHTMLButtonElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7201,10 +7201,10 @@ export interface DOMHTMLButtonElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7400,7 +7400,7 @@ export interface DOMHTMLCanvasElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -7528,9 +7528,9 @@ export interface DOMHTMLCanvasElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7539,10 +7539,10 @@ export interface DOMHTMLCanvasElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7644,9 +7644,9 @@ export interface DOMHTMLCollection {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7655,10 +7655,10 @@ export interface DOMHTMLCollection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -7778,7 +7778,7 @@ export interface DOMHTMLDListElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -7906,9 +7906,9 @@ export interface DOMHTMLDListElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -7917,10 +7917,10 @@ export interface DOMHTMLDListElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8098,7 +8098,7 @@ export interface DOMHTMLDetailsElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -8226,9 +8226,9 @@ export interface DOMHTMLDetailsElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8237,10 +8237,10 @@ export interface DOMHTMLDetailsElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8418,7 +8418,7 @@ export interface DOMHTMLDirectoryElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -8546,9 +8546,9 @@ export interface DOMHTMLDirectoryElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8557,10 +8557,10 @@ export interface DOMHTMLDirectoryElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -8738,7 +8738,7 @@ export interface DOMHTMLDivElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -8866,9 +8866,9 @@ export interface DOMHTMLDivElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -8877,10 +8877,10 @@ export interface DOMHTMLDivElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9213,9 +9213,9 @@ export interface DOMHTMLDocument {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9224,10 +9224,10 @@ export interface DOMHTMLDocument {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9423,7 +9423,7 @@ export interface DOMHTMLElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -9551,9 +9551,9 @@ export interface DOMHTMLElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9562,10 +9562,10 @@ export interface DOMHTMLElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -9760,7 +9760,7 @@ export interface DOMHTMLEmbedElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -9888,9 +9888,9 @@ export interface DOMHTMLEmbedElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -9899,10 +9899,10 @@ export interface DOMHTMLEmbedElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -10102,7 +10102,7 @@ export interface DOMHTMLFieldSetElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -10230,9 +10230,9 @@ export interface DOMHTMLFieldSetElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -10241,10 +10241,10 @@ export interface DOMHTMLFieldSetElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -10437,7 +10437,7 @@ export interface DOMHTMLFontElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -10565,9 +10565,9 @@ export interface DOMHTMLFontElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -10576,10 +10576,10 @@ export interface DOMHTMLFontElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -10808,7 +10808,7 @@ export interface DOMHTMLFormElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -10936,9 +10936,9 @@ export interface DOMHTMLFormElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -10947,10 +10947,10 @@ export interface DOMHTMLFormElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -11176,7 +11176,7 @@ export interface DOMHTMLFrameElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -11304,9 +11304,9 @@ export interface DOMHTMLFrameElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -11315,10 +11315,10 @@ export interface DOMHTMLFrameElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -11511,7 +11511,7 @@ export interface DOMHTMLFrameSetElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -11639,9 +11639,9 @@ export interface DOMHTMLFrameSetElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -11650,10 +11650,10 @@ export interface DOMHTMLFrameSetElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -11844,7 +11844,7 @@ export interface DOMHTMLHRElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -11972,9 +11972,9 @@ export interface DOMHTMLHRElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -11983,10 +11983,10 @@ export interface DOMHTMLHRElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -12167,7 +12167,7 @@ export interface DOMHTMLHeadElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -12295,9 +12295,9 @@ export interface DOMHTMLHeadElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -12306,10 +12306,10 @@ export interface DOMHTMLHeadElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -12487,7 +12487,7 @@ export interface DOMHTMLHeadingElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -12615,9 +12615,9 @@ export interface DOMHTMLHeadingElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -12626,10 +12626,10 @@ export interface DOMHTMLHeadingElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -12811,7 +12811,7 @@ export interface DOMHTMLHtmlElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -12939,9 +12939,9 @@ export interface DOMHTMLHtmlElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -12950,10 +12950,10 @@ export interface DOMHTMLHtmlElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -13184,7 +13184,7 @@ export interface DOMHTMLIFrameElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -13312,9 +13312,9 @@ export interface DOMHTMLIFrameElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -13323,10 +13323,10 @@ export interface DOMHTMLIFrameElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -13584,7 +13584,7 @@ export interface DOMHTMLImageElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -13712,9 +13712,9 @@ export interface DOMHTMLImageElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -13723,10 +13723,10 @@ export interface DOMHTMLImageElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -14104,7 +14104,7 @@ export interface DOMHTMLInputElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -14232,9 +14232,9 @@ export interface DOMHTMLInputElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -14243,10 +14243,10 @@ export interface DOMHTMLInputElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -14500,7 +14500,7 @@ export interface DOMHTMLKeygenElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -14628,9 +14628,9 @@ export interface DOMHTMLKeygenElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -14639,10 +14639,10 @@ export interface DOMHTMLKeygenElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -14832,7 +14832,7 @@ export interface DOMHTMLLIElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -14960,9 +14960,9 @@ export interface DOMHTMLLIElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -14971,10 +14971,10 @@ export interface DOMHTMLLIElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -15157,7 +15157,7 @@ export interface DOMHTMLLabelElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -15285,9 +15285,9 @@ export interface DOMHTMLLabelElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -15296,10 +15296,10 @@ export interface DOMHTMLLabelElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -15481,7 +15481,7 @@ export interface DOMHTMLLegendElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -15609,9 +15609,9 @@ export interface DOMHTMLLegendElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -15620,10 +15620,10 @@ export interface DOMHTMLLegendElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -15834,7 +15834,7 @@ export interface DOMHTMLLinkElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -15962,9 +15962,9 @@ export interface DOMHTMLLinkElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -15973,10 +15973,10 @@ export interface DOMHTMLLinkElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -16165,7 +16165,7 @@ export interface DOMHTMLMapElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -16293,9 +16293,9 @@ export interface DOMHTMLMapElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -16304,10 +16304,10 @@ export interface DOMHTMLMapElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -16528,7 +16528,7 @@ export interface DOMHTMLMarqueeElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -16656,9 +16656,9 @@ export interface DOMHTMLMarqueeElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -16667,10 +16667,10 @@ export interface DOMHTMLMarqueeElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -16957,7 +16957,7 @@ export interface DOMHTMLMediaElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -17085,9 +17085,9 @@ export interface DOMHTMLMediaElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -17096,10 +17096,10 @@ export interface DOMHTMLMediaElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -17309,7 +17309,7 @@ export interface DOMHTMLMenuElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -17437,9 +17437,9 @@ export interface DOMHTMLMenuElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -17448,10 +17448,10 @@ export interface DOMHTMLMenuElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -17641,7 +17641,7 @@ export interface DOMHTMLMetaElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -17769,9 +17769,9 @@ export interface DOMHTMLMetaElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -17780,10 +17780,10 @@ export interface DOMHTMLMetaElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -17968,7 +17968,7 @@ export interface DOMHTMLModElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -18096,9 +18096,9 @@ export interface DOMHTMLModElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -18107,10 +18107,10 @@ export interface DOMHTMLModElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -18299,7 +18299,7 @@ export interface DOMHTMLOListElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -18427,9 +18427,9 @@ export interface DOMHTMLOListElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -18438,10 +18438,10 @@ export interface DOMHTMLOListElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -18692,7 +18692,7 @@ export interface DOMHTMLObjectElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -18821,7 +18821,7 @@ export interface DOMHTMLObjectElement {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -18831,8 +18831,8 @@ export interface DOMHTMLObjectElement {
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -19034,7 +19034,7 @@ export interface DOMHTMLOptGroupElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -19162,9 +19162,9 @@ export interface DOMHTMLOptGroupElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -19173,10 +19173,10 @@ export interface DOMHTMLOptGroupElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -19377,7 +19377,7 @@ export interface DOMHTMLOptionElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -19505,9 +19505,9 @@ export interface DOMHTMLOptionElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -19516,10 +19516,10 @@ export interface DOMHTMLOptionElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -19634,9 +19634,9 @@ export interface DOMHTMLOptionsCollection {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -19645,10 +19645,10 @@ export interface DOMHTMLOptionsCollection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -19769,7 +19769,7 @@ export interface DOMHTMLParagraphElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -19897,9 +19897,9 @@ export interface DOMHTMLParagraphElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -19908,10 +19908,10 @@ export interface DOMHTMLParagraphElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -20099,7 +20099,7 @@ export interface DOMHTMLParamElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -20227,9 +20227,9 @@ export interface DOMHTMLParamElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -20238,10 +20238,10 @@ export interface DOMHTMLParamElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -20426,7 +20426,7 @@ export interface DOMHTMLPreElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -20554,9 +20554,9 @@ export interface DOMHTMLPreElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -20565,10 +20565,10 @@ export interface DOMHTMLPreElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -20672,9 +20672,9 @@ export interface DOMHTMLPropertiesCollection {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -20683,10 +20683,10 @@ export interface DOMHTMLPropertiesCollection {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -20708,10 +20708,10 @@ export interface DOMHTMLPropertiesCollection_Static {
     new (config?: DOMHTMLPropertiesCollection_ConstructProps): DOMHTMLPropertiesCollection
 }
 export declare class DOMHTMLPropertiesCollection_Static {
-    get_length(self: object): number
-    get_names(self: object): DOMDOMStringList
-    item(self: object, index: number): DOMNode
-    named_item(self: object, name: string): object
+    get_length(self: object | null): number
+    get_names(self: object | null): DOMDOMStringList
+    item(self: object | null, index: number): DOMNode
+    named_item(self: object | null, name: string): object | null
 }
 export declare var DOMHTMLPropertiesCollection: DOMHTMLPropertiesCollection_Static
 export interface DOMHTMLQuoteElement_ConstructProps extends DOMHTMLElement_ConstructProps {
@@ -20813,7 +20813,7 @@ export interface DOMHTMLQuoteElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -20941,9 +20941,9 @@ export interface DOMHTMLQuoteElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -20952,10 +20952,10 @@ export interface DOMHTMLQuoteElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -21167,7 +21167,7 @@ export interface DOMHTMLScriptElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -21295,9 +21295,9 @@ export interface DOMHTMLScriptElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -21306,10 +21306,10 @@ export interface DOMHTMLScriptElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -21549,7 +21549,7 @@ export interface DOMHTMLSelectElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -21676,9 +21676,9 @@ export interface DOMHTMLSelectElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -21687,10 +21687,10 @@ export interface DOMHTMLSelectElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -21894,7 +21894,7 @@ export interface DOMHTMLStyleElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -22022,9 +22022,9 @@ export interface DOMHTMLStyleElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -22033,10 +22033,10 @@ export interface DOMHTMLStyleElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -22217,7 +22217,7 @@ export interface DOMHTMLTableCaptionElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -22345,9 +22345,9 @@ export interface DOMHTMLTableCaptionElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -22356,10 +22356,10 @@ export interface DOMHTMLTableCaptionElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -22591,7 +22591,7 @@ export interface DOMHTMLTableCellElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -22719,9 +22719,9 @@ export interface DOMHTMLTableCellElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -22730,10 +22730,10 @@ export interface DOMHTMLTableCellElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -22945,7 +22945,7 @@ export interface DOMHTMLTableColElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -23073,9 +23073,9 @@ export interface DOMHTMLTableColElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -23084,10 +23084,10 @@ export interface DOMHTMLTableColElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -23324,7 +23324,7 @@ export interface DOMHTMLTableElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -23452,9 +23452,9 @@ export interface DOMHTMLTableElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -23463,10 +23463,10 @@ export interface DOMHTMLTableElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -23681,7 +23681,7 @@ export interface DOMHTMLTableRowElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -23809,9 +23809,9 @@ export interface DOMHTMLTableRowElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -23820,10 +23820,10 @@ export interface DOMHTMLTableRowElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -24024,7 +24024,7 @@ export interface DOMHTMLTableSectionElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -24152,9 +24152,9 @@ export interface DOMHTMLTableSectionElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -24163,10 +24163,10 @@ export interface DOMHTMLTableSectionElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -24435,7 +24435,7 @@ export interface DOMHTMLTextAreaElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -24563,9 +24563,9 @@ export interface DOMHTMLTextAreaElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -24574,10 +24574,10 @@ export interface DOMHTMLTextAreaElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -24779,7 +24779,7 @@ export interface DOMHTMLTitleElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -24907,9 +24907,9 @@ export interface DOMHTMLTitleElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -24918,10 +24918,10 @@ export interface DOMHTMLTitleElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -25101,7 +25101,7 @@ export interface DOMHTMLUListElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -25229,9 +25229,9 @@ export interface DOMHTMLUListElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -25240,10 +25240,10 @@ export interface DOMHTMLUListElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -25542,7 +25542,7 @@ export interface DOMHTMLVideoElement {
     get_item_prop(): DOMDOMSettableTokenList
     get_item_ref(): DOMDOMSettableTokenList
     get_item_scope(): boolean
-    get_item_type(): object
+    get_item_type(): object | null
     get_lang(): string
     get_outer_html(): string
     get_outer_text(): string
@@ -25670,9 +25670,9 @@ export interface DOMHTMLVideoElement {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -25681,10 +25681,10 @@ export interface DOMHTMLVideoElement {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -25828,9 +25828,9 @@ export interface DOMHistory {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -25839,10 +25839,10 @@ export interface DOMHistory {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -25949,9 +25949,9 @@ export interface DOMKeyboardEvent {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -25960,10 +25960,10 @@ export interface DOMKeyboardEvent {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26048,9 +26048,9 @@ export interface DOMLocation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26059,10 +26059,10 @@ export interface DOMLocation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26145,9 +26145,9 @@ export interface DOMMediaController {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26156,10 +26156,10 @@ export interface DOMMediaController {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26210,9 +26210,9 @@ export interface DOMMediaError {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26221,10 +26221,10 @@ export interface DOMMediaError {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26272,9 +26272,9 @@ export interface DOMMediaList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26283,10 +26283,10 @@ export interface DOMMediaList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26330,9 +26330,9 @@ export interface DOMMediaQueryList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26341,10 +26341,10 @@ export interface DOMMediaQueryList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26384,9 +26384,9 @@ export interface DOMMemoryInfo {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26395,10 +26395,10 @@ export interface DOMMemoryInfo {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26421,9 +26421,9 @@ export interface DOMMemoryInfo_Static {
     new (config?: DOMMemoryInfo_ConstructProps): DOMMemoryInfo
 }
 export declare class DOMMemoryInfo_Static {
-    get_js_heap_size_limit(self: object): number
-    get_total_js_heap_size(self: object): number
-    get_used_js_heap_size(self: object): number
+    get_js_heap_size_limit(self: object | null): number
+    get_total_js_heap_size(self: object | null): number
+    get_used_js_heap_size(self: object | null): number
 }
 export declare var DOMMemoryInfo: DOMMemoryInfo_Static
 export interface DOMMessagePort_ConstructProps extends DOMObject_ConstructProps {
@@ -26442,9 +26442,9 @@ export interface DOMMessagePort {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26453,10 +26453,10 @@ export interface DOMMessagePort {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26490,9 +26490,9 @@ export interface DOMMicroDataItemValue {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26501,10 +26501,10 @@ export interface DOMMicroDataItemValue {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26631,9 +26631,9 @@ export interface DOMMouseEvent {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26642,10 +26642,10 @@ export interface DOMMouseEvent {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26730,9 +26730,9 @@ export interface DOMNamedNodeMap {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26741,10 +26741,10 @@ export interface DOMNamedNodeMap {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26825,9 +26825,9 @@ export interface DOMNavigator {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26836,10 +26836,10 @@ export interface DOMNavigator {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -26951,9 +26951,9 @@ export interface DOMNode {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -26962,10 +26962,10 @@ export interface DOMNode {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27019,9 +27019,9 @@ export interface DOMNodeFilter {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27030,10 +27030,10 @@ export interface DOMNodeFilter {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27086,9 +27086,9 @@ export interface DOMNodeIterator {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27097,10 +27097,10 @@ export interface DOMNodeIterator {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27147,9 +27147,9 @@ export interface DOMNodeList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27158,10 +27158,10 @@ export interface DOMNodeList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27197,9 +27197,9 @@ export interface DOMObject {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27208,10 +27208,10 @@ export interface DOMObject {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27246,7 +27246,7 @@ export interface DOMPerformance {
     /* Fields of GObject.Object */
     g_type_instance:GObject.TypeInstance
     /* Methods of WebKit.DOMPerformance */
-    get_memory(): object
+    get_memory(): object | null
     get_navigation(): DOMPerformanceNavigation
     get_timing(): DOMPerformanceTiming
     now(): number
@@ -27255,9 +27255,9 @@ export interface DOMPerformance {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27266,10 +27266,10 @@ export interface DOMPerformance {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27317,9 +27317,9 @@ export interface DOMPerformanceEntry {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27328,10 +27328,10 @@ export interface DOMPerformanceEntry {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27376,9 +27376,9 @@ export interface DOMPerformanceEntryList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27387,10 +27387,10 @@ export interface DOMPerformanceEntryList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27432,9 +27432,9 @@ export interface DOMPerformanceNavigation {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27443,10 +27443,10 @@ export interface DOMPerformanceNavigation {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27528,9 +27528,9 @@ export interface DOMPerformanceTiming {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27539,10 +27539,10 @@ export interface DOMPerformanceTiming {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27676,7 +27676,7 @@ export interface DOMProcessingInstruction {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27685,8 +27685,8 @@ export interface DOMProcessingInstruction {
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27748,9 +27748,9 @@ export interface DOMPropertyNodeList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27759,10 +27759,10 @@ export interface DOMPropertyNodeList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27783,8 +27783,8 @@ export interface DOMPropertyNodeList_Static {
     new (config?: DOMPropertyNodeList_ConstructProps): DOMPropertyNodeList
 }
 export declare class DOMPropertyNodeList_Static {
-    get_length(self: object): number
-    item(self: object, index: number): DOMNode
+    get_length(self: object | null): number
+    item(self: object | null, index: number): DOMNode
 }
 export declare var DOMPropertyNodeList: DOMPropertyNodeList_Static
 export interface DOMRange_ConstructProps extends DOMObject_ConstructProps {
@@ -27843,9 +27843,9 @@ export interface DOMRange {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27854,10 +27854,10 @@ export interface DOMRange {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -27918,9 +27918,9 @@ export interface DOMScreen {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -27929,10 +27929,10 @@ export interface DOMScreen {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28058,9 +28058,9 @@ export interface DOMShadowRoot {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28069,10 +28069,10 @@ export interface DOMShadowRoot {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28137,9 +28137,9 @@ export interface DOMStorage {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28148,10 +28148,10 @@ export interface DOMStorage {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28188,9 +28188,9 @@ export interface DOMStorageInfo {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28199,10 +28199,10 @@ export interface DOMStorageInfo {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28238,9 +28238,9 @@ export interface DOMStorageQuota {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28249,10 +28249,10 @@ export interface DOMStorageQuota {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28292,9 +28292,9 @@ export interface DOMStyleMedia {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28303,10 +28303,10 @@ export interface DOMStyleMedia {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28360,9 +28360,9 @@ export interface DOMStyleSheet {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28371,10 +28371,10 @@ export interface DOMStyleSheet {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28422,9 +28422,9 @@ export interface DOMStyleSheetList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28433,10 +28433,10 @@ export interface DOMStyleSheetList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28550,7 +28550,7 @@ export interface DOMText {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28559,8 +28559,8 @@ export interface DOMText {
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28636,9 +28636,9 @@ export interface DOMTextTrack {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28647,10 +28647,10 @@ export interface DOMTextTrack {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28743,9 +28743,9 @@ export interface DOMTextTrackCue {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28754,10 +28754,10 @@ export interface DOMTextTrackCue {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28811,9 +28811,9 @@ export interface DOMTextTrackCueList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28822,10 +28822,10 @@ export interface DOMTextTrackCueList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28869,9 +28869,9 @@ export interface DOMTextTrackList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28880,10 +28880,10 @@ export interface DOMTextTrackList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -28926,9 +28926,9 @@ export interface DOMTimeRanges {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -28937,10 +28937,10 @@ export interface DOMTimeRanges {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29003,9 +29003,9 @@ export interface DOMTouch {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29014,10 +29014,10 @@ export interface DOMTouch {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29095,9 +29095,9 @@ export interface DOMTrackEvent {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29106,10 +29106,10 @@ export interface DOMTrackEvent {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29176,9 +29176,9 @@ export interface DOMTreeWalker {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29187,10 +29187,10 @@ export interface DOMTreeWalker {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29282,9 +29282,9 @@ export interface DOMUIEvent {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29293,10 +29293,10 @@ export interface DOMUIEvent {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29374,9 +29374,9 @@ export interface DOMValidityState {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29385,10 +29385,10 @@ export interface DOMValidityState {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29446,9 +29446,9 @@ export interface DOMVideoPlaybackQuality {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29457,10 +29457,10 @@ export interface DOMVideoPlaybackQuality {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29515,9 +29515,9 @@ export interface DOMVideoTrack {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29526,10 +29526,10 @@ export interface DOMVideoTrack {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29577,9 +29577,9 @@ export interface DOMVideoTrackList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29588,10 +29588,10 @@ export interface DOMVideoTrackList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29643,9 +29643,9 @@ export interface DOMWebKitNamedFlow {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29654,10 +29654,10 @@ export interface DOMWebKitNamedFlow {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29706,9 +29706,9 @@ export interface DOMWebKitPoint {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29717,10 +29717,10 @@ export interface DOMWebKitPoint {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29869,9 +29869,9 @@ export interface DOMWheelEvent {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29880,10 +29880,10 @@ export interface DOMWheelEvent {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -29967,9 +29967,9 @@ export interface DOMXPathExpression {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -29978,10 +29978,10 @@ export interface DOMXPathExpression {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30019,9 +30019,9 @@ export interface DOMXPathNSResolver {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30030,10 +30030,10 @@ export interface DOMXPathNSResolver {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30087,9 +30087,9 @@ export interface DOMXPathResult {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30098,10 +30098,10 @@ export interface DOMXPathResult {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30165,9 +30165,9 @@ export interface Download {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30176,10 +30176,10 @@ export interface Download {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30222,7 +30222,7 @@ export interface FaviconDatabase {
     g_type_instance:GObject.TypeInstance
     /* Methods of WebKit.FaviconDatabase */
     clear(): void
-    get_favicon_pixbuf(page_uri: string, width: number, height: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object): void
+    get_favicon_pixbuf(page_uri: string, width: number, height: number, cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback | null, user_data: object | null): void
     get_favicon_pixbuf_finish(result: Gio.AsyncResult): GdkPixbuf.Pixbuf
     get_favicon_uri(page_uri: string): string
     get_path(): string
@@ -30233,9 +30233,9 @@ export interface FaviconDatabase {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30244,10 +30244,10 @@ export interface FaviconDatabase {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30293,9 +30293,9 @@ export interface FileChooserRequest {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30304,10 +30304,10 @@ export interface FileChooserRequest {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30343,9 +30343,9 @@ export interface GeolocationPolicyDecision {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30354,10 +30354,10 @@ export interface GeolocationPolicyDecision {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30397,9 +30397,9 @@ export interface HitTestResult {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30408,10 +30408,10 @@ export interface HitTestResult {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30452,9 +30452,9 @@ export interface IconDatabase {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30463,10 +30463,10 @@ export interface IconDatabase {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30509,9 +30509,9 @@ export interface NetworkRequest {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30520,10 +30520,10 @@ export interface NetworkRequest {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30569,9 +30569,9 @@ export interface NetworkResponse {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30580,10 +30580,10 @@ export interface NetworkResponse {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30635,9 +30635,9 @@ export interface SecurityOrigin {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30646,10 +30646,10 @@ export interface SecurityOrigin {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30686,9 +30686,9 @@ export interface SoupAuthDialog {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30697,10 +30697,10 @@ export interface SoupAuthDialog {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30758,9 +30758,9 @@ export interface ViewportAttributes {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30769,10 +30769,10 @@ export interface ViewportAttributes {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30835,9 +30835,9 @@ export interface WebBackForwardList {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30846,10 +30846,10 @@ export interface WebBackForwardList {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30892,7 +30892,7 @@ export interface WebDataSource {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30901,10 +30901,10 @@ export interface WebDataSource {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -30955,9 +30955,9 @@ export interface WebDatabase {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -30966,10 +30966,10 @@ export interface WebDatabase {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31038,9 +31038,9 @@ export interface WebFrame {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31049,10 +31049,10 @@ export interface WebFrame {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31070,7 +31070,7 @@ export interface WebFrame {
     connect(sigName: "insecure-content-run", callback: ((obj: WebFrame, security_origin: SecurityOrigin, url: string) => void))
     connect(sigName: "load-committed", callback: ((obj: WebFrame) => void))
     connect(sigName: "resource-content-length-received", callback: ((obj: WebFrame, web_resource: WebResource, length_received: number) => void))
-    connect(sigName: "resource-load-failed", callback: ((obj: WebFrame, web_resource: WebResource, error: object) => void))
+    connect(sigName: "resource-load-failed", callback: ((obj: WebFrame, web_resource: WebResource, error: object | null) => void))
     connect(sigName: "resource-load-finished", callback: ((obj: WebFrame, web_resource: WebResource) => void))
     connect(sigName: "resource-request-starting", callback: ((obj: WebFrame, web_resource: WebResource, request: NetworkRequest, response: NetworkResponse) => void))
     connect(sigName: "resource-response-received", callback: ((obj: WebFrame, web_resource: WebResource, response: NetworkResponse) => void))
@@ -31120,9 +31120,9 @@ export interface WebHistoryItem {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31131,10 +31131,10 @@ export interface WebHistoryItem {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31190,9 +31190,9 @@ export interface WebInspector {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31201,10 +31201,10 @@ export interface WebInspector {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31263,9 +31263,9 @@ export interface WebNavigationAction {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31274,10 +31274,10 @@ export interface WebNavigationAction {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31321,9 +31321,9 @@ export interface WebPlugin {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31332,10 +31332,10 @@ export interface WebPlugin {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31373,9 +31373,9 @@ export interface WebPluginDatabase {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31384,10 +31384,10 @@ export interface WebPluginDatabase {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31426,9 +31426,9 @@ export interface WebPolicyDecision {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31437,10 +31437,10 @@ export interface WebPolicyDecision {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31484,7 +31484,7 @@ export interface WebResource {
     force_floating(): void
     freeze_notify(): void
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31493,10 +31493,10 @@ export interface WebResource {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31510,7 +31510,7 @@ export interface WebResource {
     vfunc_set_property(property_id: number, value: GObject.Value, pspec: GObject.ParamSpec): void
     /* Signals of WebKit.WebResource */
     connect(sigName: "content-length-received", callback: ((obj: WebResource, length_received: number) => void))
-    connect(sigName: "load-failed", callback: ((obj: WebResource, error: object) => void))
+    connect(sigName: "load-failed", callback: ((obj: WebResource, error: object | null) => void))
     connect(sigName: "load-finished", callback: ((obj: WebResource) => void))
     connect(sigName: "response-received", callback: ((obj: WebResource, response: NetworkResponse) => void))
     /* Signals of GObject.Object */
@@ -31661,9 +31661,9 @@ export interface WebSettings {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -31672,10 +31672,10 @@ export interface WebSettings {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -31801,6 +31801,7 @@ export interface WebView {
     double_buffered:boolean
     events:Gdk.EventMask
     expand:boolean
+    focus_on_click:boolean
     halign:Gtk.Align
     has_default:boolean
     has_focus:boolean
@@ -31920,14 +31921,14 @@ export interface WebView {
     child_notify_by_pspec(child: Gtk.Widget, pspec: GObject.ParamSpec): void
     child_set_property(child: Gtk.Widget, property_name: string, value: any): void
     child_type(): number
-    forall(callback: Gtk.Callback, callback_data: object): void
-    foreach(callback: Gtk.Callback, callback_data: object): void
+    forall(callback: Gtk.Callback, callback_data: object | null): void
+    foreach(callback: Gtk.Callback, callback_data: object | null): void
     get_border_width(): number
     get_children(): GLib.List
     get_focus_chain(): [ /* returnType */ boolean, /* focusable_widgets */ GLib.List ]
-    get_focus_child(): Gtk.Widget
-    get_focus_hadjustment(): Gtk.Adjustment
-    get_focus_vadjustment(): Gtk.Adjustment
+    get_focus_child(): Gtk.Widget | null
+    get_focus_hadjustment(): Gtk.Adjustment | null
+    get_focus_vadjustment(): Gtk.Adjustment | null
     get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     get_resize_mode(): Gtk.ResizeMode
     propagate_draw(child: Gtk.Widget, cr: cairo.Context): void
@@ -31947,7 +31948,7 @@ export interface WebView {
     add_device_events(device: Gdk.Device, events: Gdk.EventMask): void
     add_events(events: number): void
     add_mnemonic_label(label: Gtk.Widget): void
-    add_tick_callback(callback: Gtk.TickCallback, user_data: object, notify: GLib.DestroyNotify): number
+    add_tick_callback(callback: Gtk.TickCallback, user_data: object | null, notify: GLib.DestroyNotify): number
     can_activate_accel(signal_id: number): boolean
     child_focus(direction: Gtk.DirectionType): boolean
     child_notify(child_property: string): void
@@ -31965,7 +31966,7 @@ export interface WebView {
     drag_dest_add_text_targets(): void
     drag_dest_add_uri_targets(): void
     drag_dest_find_target(context: Gdk.DragContext, target_list: Gtk.TargetList | null): Gdk.Atom
-    drag_dest_get_target_list(): Gtk.TargetList
+    drag_dest_get_target_list(): Gtk.TargetList | null
     drag_dest_get_track_motion(): boolean
     drag_dest_set(flags: Gtk.DestDefaults, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_dest_set_proxy(proxy_window: Gdk.Window, protocol: Gdk.DragProtocol, use_coordinates: boolean): void
@@ -31977,7 +31978,7 @@ export interface WebView {
     drag_source_add_image_targets(): void
     drag_source_add_text_targets(): void
     drag_source_add_uri_targets(): void
-    drag_source_get_target_list(): Gtk.TargetList
+    drag_source_get_target_list(): Gtk.TargetList | null
     drag_source_set(start_button_mask: Gdk.ModifierType, targets: Gtk.TargetEntry[] | null, actions: Gdk.DragAction): void
     drag_source_set_icon_gicon(icon: Gio.Icon): void
     drag_source_set_icon_name(icon_name: string): void
@@ -31995,6 +31996,7 @@ export interface WebView {
     get_action_group(prefix: string): Gio.ActionGroup | null
     get_allocated_baseline(): number
     get_allocated_height(): number
+    get_allocated_size(): [ /* allocation */ Gtk.Allocation, /* baseline */ number | null ]
     get_allocated_width(): number
     get_allocation(): /* allocation */ Gtk.Allocation
     get_ancestor(widget_type: number): Gtk.Widget | null
@@ -32012,9 +32014,10 @@ export interface WebView {
     get_display(): Gdk.Display
     get_double_buffered(): boolean
     get_events(): number
+    get_focus_on_click(): boolean
     get_font_map(): Pango.FontMap | null
     get_font_options(): cairo.FontOptions | null
-    get_frame_clock(): Gdk.FrameClock
+    get_frame_clock(): Gdk.FrameClock | null
     get_halign(): Gtk.Align
     get_has_tooltip(): boolean
     get_has_window(): boolean
@@ -32034,7 +32037,7 @@ export interface WebView {
     get_opacity(): number
     get_pango_context(): Pango.Context
     get_parent(): Gtk.Widget | null
-    get_parent_window(): Gdk.Window
+    get_parent_window(): Gdk.Window | null
     get_path(): Gtk.WidgetPath
     get_pointer(): [ /* x */ number | null, /* y */ number | null ]
     get_preferred_height(): [ /* minimum_height */ number | null, /* natural_height */ number | null ]
@@ -32069,7 +32072,7 @@ export interface WebView {
     get_vexpand_set(): boolean
     get_visible(): boolean
     get_visual(): Gdk.Visual
-    get_window(): Gdk.Window
+    get_window(): Gdk.Window | null
     grab_add(): void
     grab_default(): void
     grab_focus(): void
@@ -32084,7 +32087,7 @@ export interface WebView {
     init_template(): void
     input_shape_combine_region(region: cairo.Region | null): void
     insert_action_group(name: string, group: Gio.ActionGroup | null): void
-    intersect(area: Gdk.Rectangle, intersection: Gdk.Rectangle | null): boolean
+    intersect(area: Gdk.Rectangle): [ /* returnType */ boolean, /* intersection */ Gdk.Rectangle | null ]
     is_ancestor(ancestor: Gtk.Widget): boolean
     is_composited(): boolean
     is_drawable(): boolean
@@ -32110,6 +32113,7 @@ export interface WebView {
     override_font(font_desc: Pango.FontDescription | null): void
     override_symbolic_color(name: string, color: Gdk.RGBA | null): void
     path(): [ /* path_length */ number | null, /* path */ string | null, /* path_reversed */ string | null ]
+    queue_allocate(): void
     queue_compute_expand(): void
     queue_draw(): void
     queue_draw_area(x: number, y: number, width: number, height: number): void
@@ -32122,7 +32126,7 @@ export interface WebView {
     remove_accelerator(accel_group: Gtk.AccelGroup, accel_key: number, accel_mods: Gdk.ModifierType): boolean
     remove_mnemonic_label(label: Gtk.Widget): void
     remove_tick_callback(id: number): void
-    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf
+    render_icon(stock_id: string, size: number, detail: string | null): GdkPixbuf.Pixbuf | null
     render_icon_pixbuf(stock_id: string, size: number): GdkPixbuf.Pixbuf | null
     reparent(new_parent: Gtk.Widget): void
     reset_rc_styles(): void
@@ -32142,6 +32146,7 @@ export interface WebView {
     set_direction(dir: Gtk.TextDirection): void
     set_double_buffered(double_buffered: boolean): void
     set_events(events: number): void
+    set_focus_on_click(focus_on_click: boolean): void
     set_font_map(font_map: Pango.FontMap | null): void
     set_font_options(options: cairo.FontOptions | null): void
     set_halign(align: Gtk.Align): void
@@ -32189,7 +32194,7 @@ export interface WebView {
     style_attach(): void
     style_get_property(property_name: string, value: any): void
     thaw_child_notify(): void
-    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number, /* dest_y */ number ]
+    translate_coordinates(dest_widget: Gtk.Widget, src_x: number, src_y: number): [ /* returnType */ boolean, /* dest_x */ number | null, /* dest_y */ number | null ]
     trigger_tooltip_query(): void
     unmap(): void
     unparent(): void
@@ -32201,9 +32206,9 @@ export interface WebView {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -32212,10 +32217,10 @@ export interface WebView {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void
@@ -32245,7 +32250,7 @@ export interface WebView {
     vfunc_check_resize(): void
     vfunc_child_type(): number
     vfunc_composite_name(child: Gtk.Widget): string
-    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object): void
+    vfunc_forall(include_internals: boolean, callback: Gtk.Callback, callback_data: object | null): void
     vfunc_get_child_property(child: Gtk.Widget, property_id: number, value: any, pspec: GObject.ParamSpec): void
     vfunc_get_path_for_child(child: Gtk.Widget): Gtk.WidgetPath
     vfunc_remove(widget: Gtk.Widget): void
@@ -32384,8 +32389,8 @@ export interface WebView {
     connect(sigName: "resource-response-received", callback: ((obj: WebView, web_frame: WebFrame, web_resource: WebResource, response: NetworkResponse) => void))
     connect(sigName: "run-file-chooser", callback: ((obj: WebView, request: FileChooserRequest) => boolean))
     connect(sigName: "script-alert", callback: ((obj: WebView, frame: WebFrame, message: string) => boolean))
-    connect(sigName: "script-confirm", callback: ((obj: WebView, frame: WebFrame, message: string, confirmed: object) => boolean))
-    connect(sigName: "script-prompt", callback: ((obj: WebView, frame: WebFrame, message: string, default_: string, text: object) => boolean))
+    connect(sigName: "script-confirm", callback: ((obj: WebView, frame: WebFrame, message: string, confirmed: object | null) => boolean))
+    connect(sigName: "script-prompt", callback: ((obj: WebView, frame: WebFrame, message: string, default_: string, text: object | null) => boolean))
     connect(sigName: "select-all", callback: ((obj: WebView) => void))
     connect(sigName: "selection-changed", callback: ((obj: WebView) => void))
     connect(sigName: "should-apply-style", callback: ((obj: WebView, set: DOMCSSStyleDeclaration, range: DOMRange) => boolean))
@@ -32403,7 +32408,7 @@ export interface WebView {
     connect(sigName: "viewport-attributes-changed", callback: ((obj: WebView, object: ViewportAttributes) => void))
     connect(sigName: "viewport-attributes-recompute-requested", callback: ((obj: WebView, object: ViewportAttributes) => void))
     connect(sigName: "web-view-ready", callback: ((obj: WebView) => boolean))
-    connect(sigName: "window-object-cleared", callback: ((obj: WebView, frame: WebFrame, context: object, window_object: object) => void))
+    connect(sigName: "window-object-cleared", callback: ((obj: WebView, frame: WebFrame, context: object | null, window_object: object | null) => void))
     /* Signals of Gtk.Container */
     connect(sigName: "add", callback: ((obj: WebView, object: Gtk.Widget) => void))
     connect(sigName: "check-resize", callback: ((obj: WebView) => void))
@@ -32449,7 +32454,7 @@ export interface WebView {
     connect(sigName: "leave-notify-event", callback: ((obj: WebView, event: Gdk.EventCrossing) => boolean))
     connect(sigName: "map", callback: ((obj: WebView) => void))
     connect(sigName: "map-event", callback: ((obj: WebView, event: Gdk.EventAny) => boolean))
-    connect(sigName: "mnemonic-activate", callback: ((obj: WebView, arg1: boolean) => boolean))
+    connect(sigName: "mnemonic-activate", callback: ((obj: WebView, group_cycling: boolean) => boolean))
     connect(sigName: "motion-notify-event", callback: ((obj: WebView, event: Gdk.EventMotion) => boolean))
     connect(sigName: "move-focus", callback: ((obj: WebView, direction: Gtk.DirectionType) => void))
     connect(sigName: "parent-set", callback: ((obj: WebView, old_parent: Gtk.Widget | null) => void))
@@ -32510,6 +32515,7 @@ export interface WebView {
     connect(sigName: "notify::double-buffered", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::events", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::expand", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
+    connect(sigName: "notify::focus-on-click", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::halign", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-default", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
     connect(sigName: "notify::has-focus", callback: ((obj: WebView, pspec: GObject.ParamSpec) => void))
@@ -32585,9 +32591,9 @@ export interface WebWindowFeatures {
     bind_property_with_closures(source_property: string, target: GObject.Object, target_property: string, flags: GObject.BindingFlags, transform_to: GObject.Closure, transform_from: GObject.Closure): GObject.Binding
     force_floating(): void
     freeze_notify(): void
-    get_data(key: string): object
+    get_data(key: string): object | null
     get_property(property_name: string, value: GObject.Value): void
-    get_qdata(quark: GLib.Quark): object
+    get_qdata(quark: GLib.Quark): object | null
     is_floating(): boolean
     notify(property_name: string): void
     notify_by_pspec(pspec: GObject.ParamSpec): void
@@ -32596,10 +32602,10 @@ export interface WebWindowFeatures {
     replace_data(key: string, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     replace_qdata(quark: GLib.Quark, oldval: object | null, newval: object | null, destroy: GLib.DestroyNotify | null, old_destroy: GLib.DestroyNotify | null): boolean
     run_dispose(): void
-    set_data(key: string, data: object): void
+    set_data(key: string, data: object | null): void
     set_property(property_name: string, value: GObject.Value): void
-    steal_data(key: string): object
-    steal_qdata(quark: GLib.Quark): object
+    steal_data(key: string): object | null
+    steal_qdata(quark: GLib.Quark): object | null
     thaw_notify(): void
     unref(): void
     watch_closure(closure: GObject.Closure): void

--- a/out/cast.ts
+++ b/out/cast.ts
@@ -1,694 +1,22 @@
+import * as Gtk from './Gtk'
+import * as Atk from './Atk'
 import * as GObject from './GObject'
+import * as Gdk from './Gdk'
+import * as GdkPixbuf from './GdkPixbuf'
+import * as Gio from './Gio'
+import * as Pango from './Pango'
+import * as Soup from './Soup'
+import * as GtkSource from './GtkSource'
+import * as WebKit from './WebKit'
+import * as AppIndicator3 from './AppIndicator3'
+import * as Notify from './Notify'
 
-let inheritanceTable = {
-    'Gtk.AboutDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.AccelGroup': [ 'GObject.Object' ],
-    'Gtk.AccelLabel': [ 'Gtk.Label', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Misc', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.AccelMap': [ 'GObject.Object' ],
-    'Gtk.Accessible': [ 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Action': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'Gtk.ActionBar': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ActionGroup': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'Gtk.Adjustment': [ 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Alignment': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.AppChooserButton': [ 'Gtk.ComboBox', 'Atk.ImplementorIface', 'Gtk.AppChooser', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.CellLayout', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.AppChooserDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.AppChooser', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.AppChooserWidget': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.AppChooser', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Application': [ 'Gio.Application', 'Gio.ActionGroup', 'Gio.ActionMap', 'GObject.Object' ],
-    'Gtk.ApplicationWindow': [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gio.ActionGroup', 'Gio.ActionMap', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Arrow': [ 'Gtk.Misc', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ArrowAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Image', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.AspectFrame': [ 'Gtk.Frame', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Assistant': [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Bin': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.BooleanCellAccessible': [ 'Gtk.RendererCellAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.CellAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Box': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Builder': [ 'GObject.Object' ],
-    'Gtk.Button': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ButtonAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ButtonBox': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Calendar': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellAccessible': [ 'Gtk.Accessible', 'Atk.Action', 'Atk.Component', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.CellArea': [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'Gtk.CellLayout', 'GObject.Object' ],
-    'Gtk.CellAreaBox': [ 'Gtk.CellArea', 'Gtk.Buildable', 'Gtk.CellLayout', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellAreaContext': [ 'GObject.Object' ],
-    'Gtk.CellRenderer': [ 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererAccel': [ 'Gtk.CellRendererText', 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererCombo': [ 'Gtk.CellRendererText', 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererPixbuf': [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererProgress': [ 'Gtk.CellRenderer', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererSpin': [ 'Gtk.CellRendererText', 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererSpinner': [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererText': [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellRendererToggle': [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CellView': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellLayout', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CheckButton': [ 'Gtk.ToggleButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CheckMenuItem': [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.CheckMenuItemAccessible': [ 'Gtk.MenuItemAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Clipboard': [ 'GObject.Object' ],
-    'Gtk.ColorButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ColorChooser', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ColorChooserDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.ColorChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ColorChooserWidget': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.ColorChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ColorSelection': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ColorSelectionDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ComboBox': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.CellLayout', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ComboBoxAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ComboBoxText': [ 'Gtk.ComboBox', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.CellLayout', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Container': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ContainerAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ContainerCellAccessible': [ 'Gtk.CellAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.CssProvider': [ 'GObject.Object', 'Gtk.StyleProvider' ],
-    'Gtk.Dialog': [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.DrawingArea': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Entry': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.Editable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.EntryAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Action', 'Atk.Component', 'Atk.EditableText', 'Atk.Text', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.EntryBuffer': [ 'GObject.Object' ],
-    'Gtk.EntryCompletion': [ 'GObject.Object', 'Gtk.Buildable', 'Gtk.CellLayout' ],
-    'Gtk.EntryIconAccessible': [ 'Atk.Object', 'Atk.Action', 'Atk.Component', 'GObject.Object' ],
-    'Gtk.EventBox': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.EventController': [ 'GObject.Object' ],
-    'Gtk.Expander': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ExpanderAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.FileChooserButton': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FileChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FileChooserDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FileChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FileChooserWidget': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FileChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FileFilter': [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'GObject.Object' ],
-    'Gtk.Fixed': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FlowBox': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FlowBoxAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.FlowBoxChild': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FlowBoxChildAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.FontButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.FontChooser', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FontChooserDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FontChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FontChooserWidget': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FontChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FontSelection': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FontSelectionDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Frame': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.FrameAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.GLArea': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Gesture': [ 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureDrag': [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureLongPress': [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureMultiPress': [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GesturePan': [ 'Gtk.GestureDrag', 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureRotate': [ 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureSingle': [ 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureSwipe': [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.GestureZoom': [ 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ],
-    'Gtk.Grid': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HBox': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HButtonBox': [ 'Gtk.ButtonBox', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Box', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HPaned': [ 'Gtk.Paned', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HSV': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HScale': [ 'Gtk.Scale', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HScrollbar': [ 'Gtk.Scrollbar', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HSeparator': [ 'Gtk.Separator', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HandleBox': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.HeaderBar': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.IMContext': [ 'GObject.Object' ],
-    'Gtk.IMContextSimple': [ 'Gtk.IMContext', 'GObject.Object' ],
-    'Gtk.IMMulticontext': [ 'Gtk.IMContext', 'GObject.Object' ],
-    'Gtk.IconFactory': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'Gtk.IconInfo': [ 'GObject.Object' ],
-    'Gtk.IconTheme': [ 'GObject.Object' ],
-    'Gtk.IconView': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellLayout', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.IconViewAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Image': [ 'Gtk.Misc', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ImageAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Image', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ImageCellAccessible': [ 'Gtk.RendererCellAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.CellAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ImageMenuItem': [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.InfoBar': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Invisible': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Label': [ 'Gtk.Misc', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.LabelAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Hypertext', 'Atk.Text', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Layout': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.LevelBar': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.LevelBarAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.LinkButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.LinkButtonAccessible': [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.HyperlinkImpl', 'Atk.Image', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ListBox': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ListBoxAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ListBoxRow': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ListBoxRowAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ListStore': [ 'GObject.Object', 'Gtk.Buildable', 'Gtk.TreeDragDest', 'Gtk.TreeDragSource', 'Gtk.TreeModel', 'Gtk.TreeSortable' ],
-    'Gtk.LockButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.LockButtonAccessible': [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Menu': [ 'Gtk.MenuShell', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MenuAccessible': [ 'Gtk.MenuShellAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.MenuBar': [ 'Gtk.MenuShell', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MenuButton': [ 'Gtk.ToggleButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MenuButtonAccessible': [ 'Gtk.ToggleButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ButtonAccessible', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.MenuItem': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MenuItemAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.MenuShell': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MenuShellAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.MenuToolButton': [ 'Gtk.ToolButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToolItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MessageDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Misc': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ModelButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.MountOperation': [ 'Gio.MountOperation', 'GObject.Object' ],
-    'Gtk.Notebook': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.NotebookAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.NotebookPageAccessible': [ 'Atk.Object', 'Atk.Component', 'GObject.Object' ],
-    'Gtk.NumerableIcon': [ 'Gio.EmblemedIcon', 'Gio.Icon', 'GObject.Object' ],
-    'Gtk.OffscreenWindow': [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Overlay': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.PageSetup': [ 'GObject.Object' ],
-    'Gtk.Paned': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.PanedAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.PlacesSidebar': [ 'Gtk.ScrolledWindow', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Plug': [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Popover': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.PopoverAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.PopoverMenu': [ 'Gtk.Popover', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.PrintContext': [ 'GObject.Object' ],
-    'Gtk.PrintOperation': [ 'GObject.Object', 'Gtk.PrintOperationPreview' ],
-    'Gtk.PrintSettings': [ 'GObject.Object' ],
-    'Gtk.ProgressBar': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ProgressBarAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.RadioAction': [ 'Gtk.ToggleAction', 'Gtk.Buildable', 'Gtk.Action', 'GObject.Object' ],
-    'Gtk.RadioButton': [ 'Gtk.CheckButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToggleButton', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.RadioButtonAccessible': [ 'Gtk.ToggleButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ButtonAccessible', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.RadioMenuItem': [ 'Gtk.CheckMenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.MenuItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.RadioMenuItemAccessible': [ 'Gtk.CheckMenuItemAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.MenuItemAccessible', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.RadioToolButton': [ 'Gtk.ToggleToolButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToolButton', 'Gtk.ToolItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Range': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.RangeAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.RcStyle': [ 'GObject.Object' ],
-    'Gtk.RecentAction': [ 'Gtk.Action', 'Gtk.Buildable', 'Gtk.RecentChooser', 'GObject.Object' ],
-    'Gtk.RecentChooserDialog': [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.RecentChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.RecentChooserMenu': [ 'Gtk.Menu', 'Atk.ImplementorIface', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.RecentChooser', 'Gtk.MenuShell', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.RecentChooserWidget': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.RecentChooser', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.RecentFilter': [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'GObject.Object' ],
-    'Gtk.RecentManager': [ 'GObject.Object' ],
-    'Gtk.RendererCellAccessible': [ 'Gtk.CellAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Revealer': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Scale': [ 'Gtk.Range', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ScaleAccessible': [ 'Gtk.RangeAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ScaleButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ScaleButtonAccessible': [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Atk.Value', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Scrollbar': [ 'Gtk.Range', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ScrolledWindow': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ScrolledWindowAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.SearchBar': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SearchEntry': [ 'Gtk.Entry', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.Editable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Separator': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SeparatorMenuItem': [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SeparatorToolItem': [ 'Gtk.ToolItem', 'Atk.ImplementorIface', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Settings': [ 'GObject.Object', 'Gtk.StyleProvider' ],
-    'Gtk.SizeGroup': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'Gtk.Socket': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SpinButton': [ 'Gtk.Entry', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.Editable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SpinButtonAccessible': [ 'Gtk.EntryAccessible', 'Atk.Action', 'Atk.Component', 'Atk.EditableText', 'Atk.Text', 'Atk.Value', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Spinner': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SpinnerAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Image', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Stack': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.StackSidebar': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.StackSwitcher': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.StatusIcon': [ 'GObject.Object' ],
-    'Gtk.Statusbar': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.StatusbarAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Style': [ 'GObject.Object' ],
-    'Gtk.StyleContext': [ 'GObject.Object' ],
-    'Gtk.StyleProperties': [ 'GObject.Object', 'Gtk.StyleProvider' ],
-    'Gtk.Switch': [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.SwitchAccessible': [ 'Gtk.WidgetAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Table': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.TearoffMenuItem': [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.TextBuffer': [ 'GObject.Object' ],
-    'Gtk.TextCellAccessible': [ 'Gtk.RendererCellAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Text', 'Gtk.CellAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.TextChildAnchor': [ 'GObject.Object' ],
-    'Gtk.TextMark': [ 'GObject.Object' ],
-    'Gtk.TextTag': [ 'GObject.Object' ],
-    'Gtk.TextTagTable': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'Gtk.TextView': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.TextViewAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.EditableText', 'Atk.StreamableContent', 'Atk.Text', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ThemingEngine': [ 'GObject.Object' ],
-    'Gtk.ToggleAction': [ 'Gtk.Action', 'Gtk.Buildable', 'GObject.Object' ],
-    'Gtk.ToggleButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ToggleButtonAccessible': [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.ToggleToolButton': [ 'Gtk.ToolButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToolItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ToolButton': [ 'Gtk.ToolItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ToolItem': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ToolItemGroup': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.ToolShell', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.ToolPalette': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Toolbar': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.ToolShell', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Tooltip': [ 'GObject.Object' ],
-    'Gtk.ToplevelAccessible': [ 'Atk.Object', 'GObject.Object' ],
-    'Gtk.TreeModelFilter': [ 'GObject.Object', 'Gtk.TreeDragSource', 'Gtk.TreeModel' ],
-    'Gtk.TreeModelSort': [ 'GObject.Object', 'Gtk.TreeDragSource', 'Gtk.TreeModel', 'Gtk.TreeSortable' ],
-    'Gtk.TreeSelection': [ 'GObject.Object' ],
-    'Gtk.TreeStore': [ 'GObject.Object', 'Gtk.Buildable', 'Gtk.TreeDragDest', 'Gtk.TreeDragSource', 'Gtk.TreeModel', 'Gtk.TreeSortable' ],
-    'Gtk.TreeView': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.TreeViewAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Atk.Table', 'Gtk.CellAccessibleParent', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.TreeViewColumn': [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'Gtk.CellLayout', 'GObject.Object' ],
-    'Gtk.UIManager': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'Gtk.VBox': [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.VButtonBox': [ 'Gtk.ButtonBox', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Box', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.VPaned': [ 'Gtk.Paned', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.VScale': [ 'Gtk.Scale', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.VScrollbar': [ 'Gtk.Scrollbar', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.VSeparator': [ 'Gtk.Separator', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Viewport': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.VolumeButton': [ 'Gtk.ScaleButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.Widget': [ 'GObject.InitiallyUnowned', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.Object' ],
-    'Gtk.WidgetAccessible': [ 'Gtk.Accessible', 'Atk.Component', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.Window': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'Gtk.WindowAccessible': [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Window', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ],
-    'Gtk.WindowGroup': [ 'GObject.Object' ],
-    'Atk.GObjectAccessible': [ 'Atk.Object', 'GObject.Object' ],
-    'Atk.Hyperlink': [ 'GObject.Object', 'Atk.Action' ],
-    'Atk.Misc': [ 'GObject.Object' ],
-    'Atk.NoOpObject': [ 'Atk.Object', 'Atk.Action', 'Atk.Component', 'Atk.Document', 'Atk.EditableText', 'Atk.Hypertext', 'Atk.Image', 'Atk.Selection', 'Atk.Table', 'Atk.TableCell', 'Atk.Text', 'Atk.Value', 'Atk.Window', 'GObject.Object' ],
-    'Atk.NoOpObjectFactory': [ 'Atk.ObjectFactory', 'GObject.Object' ],
-    'Atk.Object': [ 'GObject.Object' ],
-    'Atk.ObjectFactory': [ 'GObject.Object' ],
-    'Atk.Plug': [ 'Atk.Object', 'Atk.Component', 'GObject.Object' ],
-    'Atk.Registry': [ 'GObject.Object' ],
-    'Atk.Relation': [ 'GObject.Object' ],
-    'Atk.RelationSet': [ 'GObject.Object' ],
-    'Atk.Socket': [ 'Atk.Object', 'Atk.Component', 'GObject.Object' ],
-    'Atk.StateSet': [ 'GObject.Object' ],
-    'Atk.Util': [ 'GObject.Object' ],
-    'GObject.Binding': [ 'GObject.Object' ],
-    'GObject.InitiallyUnowned': [ 'GObject.Object' ],
-    'GObject.ParamSpecBoolean': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecBoxed': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecChar': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecDouble': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecEnum': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecFlags': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecFloat': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecGType': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecInt': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecInt64': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecLong': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecObject': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecOverride': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecParam': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecPointer': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecString': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecUChar': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecUInt': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecUInt64': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecULong': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecUnichar': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecValueArray': [ 'GObject.ParamSpec' ],
-    'GObject.ParamSpecVariant': [ 'GObject.ParamSpec' ],
-    'GObject.TypeModule': [ 'GObject.Object', 'GObject.TypePlugin' ],
-    'Gdk.AppLaunchContext': [ 'Gio.AppLaunchContext', 'GObject.Object' ],
-    'Gdk.Cursor': [ 'GObject.Object' ],
-    'Gdk.Device': [ 'GObject.Object' ],
-    'Gdk.DeviceManager': [ 'GObject.Object' ],
-    'Gdk.Display': [ 'GObject.Object' ],
-    'Gdk.DisplayManager': [ 'GObject.Object' ],
-    'Gdk.DragContext': [ 'GObject.Object' ],
-    'Gdk.FrameClock': [ 'GObject.Object' ],
-    'Gdk.GLContext': [ 'GObject.Object' ],
-    'Gdk.Keymap': [ 'GObject.Object' ],
-    'Gdk.Screen': [ 'GObject.Object' ],
-    'Gdk.Visual': [ 'GObject.Object' ],
-    'Gdk.Window': [ 'GObject.Object' ],
-    'GdkPixbuf.Pixbuf': [ 'GObject.Object', 'Gio.Icon', 'Gio.LoadableIcon' ],
-    'GdkPixbuf.PixbufAnimation': [ 'GObject.Object' ],
-    'GdkPixbuf.PixbufAnimationIter': [ 'GObject.Object' ],
-    'GdkPixbuf.PixbufLoader': [ 'GObject.Object' ],
-    'GdkPixbuf.PixbufSimpleAnim': [ 'GdkPixbuf.PixbufAnimation', 'GObject.Object' ],
-    'GdkPixbuf.PixbufSimpleAnimIter': [ 'GdkPixbuf.PixbufAnimationIter', 'GObject.Object' ],
-    'Gio.AppInfoMonitor': [ 'GObject.Object' ],
-    'Gio.AppLaunchContext': [ 'GObject.Object' ],
-    'Gio.Application': [ 'GObject.Object', 'Gio.ActionGroup', 'Gio.ActionMap' ],
-    'Gio.ApplicationCommandLine': [ 'GObject.Object' ],
-    'Gio.BufferedInputStream': [ 'Gio.FilterInputStream', 'Gio.Seekable', 'Gio.InputStream', 'GObject.Object' ],
-    'Gio.BufferedOutputStream': [ 'Gio.FilterOutputStream', 'Gio.Seekable', 'Gio.OutputStream', 'GObject.Object' ],
-    'Gio.BytesIcon': [ 'GObject.Object', 'Gio.Icon', 'Gio.LoadableIcon' ],
-    'Gio.Cancellable': [ 'GObject.Object' ],
-    'Gio.CharsetConverter': [ 'GObject.Object', 'Gio.Converter', 'Gio.Initable' ],
-    'Gio.ConverterInputStream': [ 'Gio.FilterInputStream', 'Gio.PollableInputStream', 'Gio.InputStream', 'GObject.Object' ],
-    'Gio.ConverterOutputStream': [ 'Gio.FilterOutputStream', 'Gio.PollableOutputStream', 'Gio.OutputStream', 'GObject.Object' ],
-    'Gio.Credentials': [ 'GObject.Object' ],
-    'Gio.DBusActionGroup': [ 'GObject.Object', 'Gio.ActionGroup', 'Gio.RemoteActionGroup' ],
-    'Gio.DBusAuthObserver': [ 'GObject.Object' ],
-    'Gio.DBusConnection': [ 'GObject.Object', 'Gio.AsyncInitable', 'Gio.Initable' ],
-    'Gio.DBusInterfaceSkeleton': [ 'GObject.Object', 'Gio.DBusInterface' ],
-    'Gio.DBusMenuModel': [ 'Gio.MenuModel', 'GObject.Object' ],
-    'Gio.DBusMessage': [ 'GObject.Object' ],
-    'Gio.DBusMethodInvocation': [ 'GObject.Object' ],
-    'Gio.DBusObjectManagerClient': [ 'GObject.Object', 'Gio.AsyncInitable', 'Gio.DBusObjectManager', 'Gio.Initable' ],
-    'Gio.DBusObjectManagerServer': [ 'GObject.Object', 'Gio.DBusObjectManager' ],
-    'Gio.DBusObjectProxy': [ 'GObject.Object', 'Gio.DBusObject' ],
-    'Gio.DBusObjectSkeleton': [ 'GObject.Object', 'Gio.DBusObject' ],
-    'Gio.DBusProxy': [ 'GObject.Object', 'Gio.AsyncInitable', 'Gio.DBusInterface', 'Gio.Initable' ],
-    'Gio.DBusServer': [ 'GObject.Object', 'Gio.Initable' ],
-    'Gio.DataInputStream': [ 'Gio.BufferedInputStream', 'Gio.Seekable', 'Gio.FilterInputStream', 'Gio.InputStream', 'GObject.Object' ],
-    'Gio.DataOutputStream': [ 'Gio.FilterOutputStream', 'Gio.Seekable', 'Gio.OutputStream', 'GObject.Object' ],
-    'Gio.DesktopAppInfo': [ 'GObject.Object', 'Gio.AppInfo' ],
-    'Gio.Emblem': [ 'GObject.Object', 'Gio.Icon' ],
-    'Gio.EmblemedIcon': [ 'GObject.Object', 'Gio.Icon' ],
-    'Gio.FileEnumerator': [ 'GObject.Object' ],
-    'Gio.FileIOStream': [ 'Gio.IOStream', 'Gio.Seekable', 'GObject.Object' ],
-    'Gio.FileIcon': [ 'GObject.Object', 'Gio.Icon', 'Gio.LoadableIcon' ],
-    'Gio.FileInfo': [ 'GObject.Object' ],
-    'Gio.FileInputStream': [ 'Gio.InputStream', 'Gio.Seekable', 'GObject.Object' ],
-    'Gio.FileMonitor': [ 'GObject.Object' ],
-    'Gio.FileOutputStream': [ 'Gio.OutputStream', 'Gio.Seekable', 'GObject.Object' ],
-    'Gio.FilenameCompleter': [ 'GObject.Object' ],
-    'Gio.FilterInputStream': [ 'Gio.InputStream', 'GObject.Object' ],
-    'Gio.FilterOutputStream': [ 'Gio.OutputStream', 'GObject.Object' ],
-    'Gio.IOModule': [ 'GObject.TypeModule', 'GObject.TypePlugin', 'GObject.Object' ],
-    'Gio.IOStream': [ 'GObject.Object' ],
-    'Gio.InetAddress': [ 'GObject.Object' ],
-    'Gio.InetAddressMask': [ 'GObject.Object', 'Gio.Initable' ],
-    'Gio.InetSocketAddress': [ 'Gio.SocketAddress', 'Gio.SocketConnectable', 'GObject.Object' ],
-    'Gio.InputStream': [ 'GObject.Object' ],
-    'Gio.ListStore': [ 'GObject.Object', 'Gio.ListModel' ],
-    'Gio.MemoryInputStream': [ 'Gio.InputStream', 'Gio.PollableInputStream', 'Gio.Seekable', 'GObject.Object' ],
-    'Gio.MemoryOutputStream': [ 'Gio.OutputStream', 'Gio.PollableOutputStream', 'Gio.Seekable', 'GObject.Object' ],
-    'Gio.Menu': [ 'Gio.MenuModel', 'GObject.Object' ],
-    'Gio.MenuAttributeIter': [ 'GObject.Object' ],
-    'Gio.MenuItem': [ 'GObject.Object' ],
-    'Gio.MenuLinkIter': [ 'GObject.Object' ],
-    'Gio.MenuModel': [ 'GObject.Object' ],
-    'Gio.MountOperation': [ 'GObject.Object' ],
-    'Gio.NativeVolumeMonitor': [ 'Gio.VolumeMonitor', 'GObject.Object' ],
-    'Gio.NetworkAddress': [ 'GObject.Object', 'Gio.SocketConnectable' ],
-    'Gio.NetworkService': [ 'GObject.Object', 'Gio.SocketConnectable' ],
-    'Gio.Notification': [ 'GObject.Object' ],
-    'Gio.OutputStream': [ 'GObject.Object' ],
-    'Gio.Permission': [ 'GObject.Object' ],
-    'Gio.PropertyAction': [ 'GObject.Object', 'Gio.Action' ],
-    'Gio.ProxyAddress': [ 'Gio.InetSocketAddress', 'Gio.SocketConnectable', 'Gio.SocketAddress', 'GObject.Object' ],
-    'Gio.ProxyAddressEnumerator': [ 'Gio.SocketAddressEnumerator', 'GObject.Object' ],
-    'Gio.Resolver': [ 'GObject.Object' ],
-    'Gio.Settings': [ 'GObject.Object' ],
-    'Gio.SimpleAction': [ 'GObject.Object', 'Gio.Action' ],
-    'Gio.SimpleActionGroup': [ 'GObject.Object', 'Gio.ActionGroup', 'Gio.ActionMap' ],
-    'Gio.SimpleAsyncResult': [ 'GObject.Object', 'Gio.AsyncResult' ],
-    'Gio.SimpleIOStream': [ 'Gio.IOStream', 'GObject.Object' ],
-    'Gio.SimplePermission': [ 'Gio.Permission', 'GObject.Object' ],
-    'Gio.SimpleProxyResolver': [ 'GObject.Object', 'Gio.ProxyResolver' ],
-    'Gio.Socket': [ 'GObject.Object', 'Gio.DatagramBased', 'Gio.Initable' ],
-    'Gio.SocketAddress': [ 'GObject.Object', 'Gio.SocketConnectable' ],
-    'Gio.SocketAddressEnumerator': [ 'GObject.Object' ],
-    'Gio.SocketClient': [ 'GObject.Object' ],
-    'Gio.SocketConnection': [ 'Gio.IOStream', 'GObject.Object' ],
-    'Gio.SocketControlMessage': [ 'GObject.Object' ],
-    'Gio.SocketListener': [ 'GObject.Object' ],
-    'Gio.SocketService': [ 'Gio.SocketListener', 'GObject.Object' ],
-    'Gio.Subprocess': [ 'GObject.Object', 'Gio.Initable' ],
-    'Gio.SubprocessLauncher': [ 'GObject.Object' ],
-    'Gio.Task': [ 'GObject.Object', 'Gio.AsyncResult' ],
-    'Gio.TcpConnection': [ 'Gio.SocketConnection', 'Gio.IOStream', 'GObject.Object' ],
-    'Gio.TcpWrapperConnection': [ 'Gio.TcpConnection', 'Gio.SocketConnection', 'Gio.IOStream', 'GObject.Object' ],
-    'Gio.TestDBus': [ 'GObject.Object' ],
-    'Gio.ThemedIcon': [ 'GObject.Object', 'Gio.Icon' ],
-    'Gio.ThreadedSocketService': [ 'Gio.SocketService', 'Gio.SocketListener', 'GObject.Object' ],
-    'Gio.TlsCertificate': [ 'GObject.Object' ],
-    'Gio.TlsConnection': [ 'Gio.IOStream', 'GObject.Object' ],
-    'Gio.TlsDatabase': [ 'GObject.Object' ],
-    'Gio.TlsInteraction': [ 'GObject.Object' ],
-    'Gio.TlsPassword': [ 'GObject.Object' ],
-    'Gio.UnixConnection': [ 'Gio.SocketConnection', 'Gio.IOStream', 'GObject.Object' ],
-    'Gio.UnixCredentialsMessage': [ 'Gio.SocketControlMessage', 'GObject.Object' ],
-    'Gio.UnixFDList': [ 'GObject.Object' ],
-    'Gio.UnixFDMessage': [ 'Gio.SocketControlMessage', 'GObject.Object' ],
-    'Gio.UnixInputStream': [ 'Gio.InputStream', 'Gio.FileDescriptorBased', 'Gio.PollableInputStream', 'GObject.Object' ],
-    'Gio.UnixMountMonitor': [ 'GObject.Object' ],
-    'Gio.UnixOutputStream': [ 'Gio.OutputStream', 'Gio.FileDescriptorBased', 'Gio.PollableOutputStream', 'GObject.Object' ],
-    'Gio.UnixSocketAddress': [ 'Gio.SocketAddress', 'Gio.SocketConnectable', 'GObject.Object' ],
-    'Gio.Vfs': [ 'GObject.Object' ],
-    'Gio.VolumeMonitor': [ 'GObject.Object' ],
-    'Gio.ZlibCompressor': [ 'GObject.Object', 'Gio.Converter' ],
-    'Gio.ZlibDecompressor': [ 'GObject.Object', 'Gio.Converter' ],
-    'Pango.Context': [ 'GObject.Object' ],
-    'Pango.Engine': [ 'GObject.Object' ],
-    'Pango.EngineLang': [ 'Pango.Engine', 'GObject.Object' ],
-    'Pango.EngineShape': [ 'Pango.Engine', 'GObject.Object' ],
-    'Pango.Font': [ 'GObject.Object' ],
-    'Pango.FontFace': [ 'GObject.Object' ],
-    'Pango.FontFamily': [ 'GObject.Object' ],
-    'Pango.FontMap': [ 'GObject.Object' ],
-    'Pango.Fontset': [ 'GObject.Object' ],
-    'Pango.FontsetSimple': [ 'Pango.Fontset', 'GObject.Object' ],
-    'Pango.Layout': [ 'GObject.Object' ],
-    'Pango.Renderer': [ 'GObject.Object' ],
-    'Soup.Address': [ 'GObject.Object', 'Gio.SocketConnectable' ],
-    'Soup.Auth': [ 'GObject.Object' ],
-    'Soup.AuthBasic': [ 'Soup.Auth', 'GObject.Object' ],
-    'Soup.AuthDigest': [ 'Soup.Auth', 'GObject.Object' ],
-    'Soup.AuthDomain': [ 'GObject.Object' ],
-    'Soup.AuthDomainBasic': [ 'Soup.AuthDomain', 'GObject.Object' ],
-    'Soup.AuthDomainDigest': [ 'Soup.AuthDomain', 'GObject.Object' ],
-    'Soup.AuthManager': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.AuthNTLM': [ 'Soup.Auth', 'GObject.Object' ],
-    'Soup.Cache': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.ContentDecoder': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.ContentSniffer': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.CookieJar': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.CookieJarDB': [ 'Soup.CookieJar', 'Soup.SessionFeature', 'GObject.Object' ],
-    'Soup.CookieJarText': [ 'Soup.CookieJar', 'Soup.SessionFeature', 'GObject.Object' ],
-    'Soup.Logger': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.Message': [ 'GObject.Object' ],
-    'Soup.MultipartInputStream': [ 'Gio.FilterInputStream', 'Gio.PollableInputStream', 'Gio.InputStream', 'GObject.Object' ],
-    'Soup.ProxyResolverDefault': [ 'GObject.Object', 'Soup.ProxyURIResolver', 'Soup.SessionFeature' ],
-    'Soup.Request': [ 'GObject.Object', 'Gio.Initable' ],
-    'Soup.RequestData': [ 'Soup.Request', 'Gio.Initable', 'GObject.Object' ],
-    'Soup.RequestFile': [ 'Soup.Request', 'Gio.Initable', 'GObject.Object' ],
-    'Soup.RequestHTTP': [ 'Soup.Request', 'Gio.Initable', 'GObject.Object' ],
-    'Soup.Requester': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'Soup.Server': [ 'GObject.Object' ],
-    'Soup.Session': [ 'GObject.Object' ],
-    'Soup.SessionAsync': [ 'Soup.Session', 'GObject.Object' ],
-    'Soup.SessionSync': [ 'Soup.Session', 'GObject.Object' ],
-    'Soup.Socket': [ 'GObject.Object', 'Gio.Initable' ],
-    'Soup.WebsocketConnection': [ 'GObject.Object' ],
-    'GtkSource.Buffer': [ 'Gtk.TextBuffer', 'GObject.Object' ],
-    'GtkSource.Completion': [ 'GObject.Object', 'Gtk.Buildable' ],
-    'GtkSource.CompletionContext': [ 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.CompletionInfo': [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.CompletionItem': [ 'GObject.Object', 'GtkSource.CompletionProposal' ],
-    'GtkSource.CompletionWords': [ 'GObject.Object', 'GtkSource.CompletionProvider' ],
-    'GtkSource.File': [ 'GObject.Object' ],
-    'GtkSource.FileLoader': [ 'GObject.Object' ],
-    'GtkSource.FileSaver': [ 'GObject.Object' ],
-    'GtkSource.Gutter': [ 'GObject.Object' ],
-    'GtkSource.GutterRenderer': [ 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.GutterRendererPixbuf': [ 'GtkSource.GutterRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.GutterRendererText': [ 'GtkSource.GutterRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.Language': [ 'GObject.Object' ],
-    'GtkSource.LanguageManager': [ 'GObject.Object' ],
-    'GtkSource.Map': [ 'GtkSource.View', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.TextView', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.Mark': [ 'Gtk.TextMark', 'GObject.Object' ],
-    'GtkSource.MarkAttributes': [ 'GObject.Object' ],
-    'GtkSource.PrintCompositor': [ 'GObject.Object' ],
-    'GtkSource.SearchContext': [ 'GObject.Object' ],
-    'GtkSource.SearchSettings': [ 'GObject.Object' ],
-    'GtkSource.Style': [ 'GObject.Object' ],
-    'GtkSource.StyleScheme': [ 'GObject.Object' ],
-    'GtkSource.StyleSchemeChooserButton': [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'GtkSource.StyleSchemeChooser', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.StyleSchemeChooserWidget': [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GtkSource.StyleSchemeChooser', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'GtkSource.StyleSchemeManager': [ 'GObject.Object' ],
-    'GtkSource.View': [ 'Gtk.TextView', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'WebKit.DOMAttr': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMAudioTrack': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMAudioTrackList': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMBarInfo': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMBarProp': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMBatteryManager': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMBlob': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCDATASection': [ 'WebKit.DOMText', 'WebKit.DOMEventTarget', 'WebKit.DOMCharacterData', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCSSRule': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCSSRuleList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCSSStyleDeclaration': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCSSStyleSheet': [ 'WebKit.DOMStyleSheet', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCSSValue': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMCharacterData': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMComment': [ 'WebKit.DOMCharacterData', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMConsole': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMApplicationCache': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMDOMImplementation': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMMimeType': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMMimeTypeArray': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMNamedFlowCollection': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMPlugin': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMPluginArray': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMSecurityPolicy': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMSelection': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMSettableTokenList': [ 'WebKit.DOMDOMTokenList', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMStringList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMStringMap': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMTokenList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDOMWindow': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMDOMWindowCSS': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDatabase': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDocument': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDocumentFragment': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMDocumentType': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMElement': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMEntityReference': [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMEvent': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMFile': [ 'WebKit.DOMBlob', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMFileList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMGamepad': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMGamepadList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMGeolocation': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLAnchorElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLAppletElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLAreaElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLAudioElement': [ 'WebKit.DOMHTMLMediaElement', 'WebKit.DOMEventTarget', 'WebKit.DOMHTMLElement', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLBRElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLBaseElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLBaseFontElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLBodyElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLButtonElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLCanvasElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLCollection': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLDListElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLDetailsElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLDirectoryElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLDivElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLDocument': [ 'WebKit.DOMDocument', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLElement': [ 'WebKit.DOMElement', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLEmbedElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLFieldSetElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLFontElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLFormElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLFrameElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLFrameSetElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLHRElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLHeadElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLHeadingElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLHtmlElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLIFrameElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLImageElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLInputElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLKeygenElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLLIElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLLabelElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLLegendElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLLinkElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLMapElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLMarqueeElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLMediaElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLMenuElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLMetaElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLModElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLOListElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLObjectElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLOptGroupElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLOptionElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLOptionsCollection': [ 'WebKit.DOMHTMLCollection', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLParagraphElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLParamElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLPreElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLPropertiesCollection': [ 'WebKit.DOMHTMLCollection', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLQuoteElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLScriptElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLSelectElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLStyleElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTableCaptionElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTableCellElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTableColElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTableElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTableRowElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTableSectionElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTextAreaElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLTitleElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLUListElement': [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHTMLVideoElement': [ 'WebKit.DOMHTMLMediaElement', 'WebKit.DOMEventTarget', 'WebKit.DOMHTMLElement', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMHistory': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMKeyboardEvent': [ 'WebKit.DOMUIEvent', 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMLocation': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMMediaController': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMMediaError': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMMediaList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMMediaQueryList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMMemoryInfo': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMMessagePort': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMMicroDataItemValue': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMMouseEvent': [ 'WebKit.DOMUIEvent', 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMNamedNodeMap': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMNavigator': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMNode': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMNodeFilter': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMNodeIterator': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMNodeList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMObject': [ 'GObject.Object' ],
-    'WebKit.DOMPerformance': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMPerformanceEntry': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMPerformanceEntryList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMPerformanceNavigation': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMPerformanceTiming': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMProcessingInstruction': [ 'WebKit.DOMCharacterData', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMPropertyNodeList': [ 'WebKit.DOMNodeList', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMRange': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMScreen': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMShadowRoot': [ 'WebKit.DOMDocumentFragment', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMStorage': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMStorageInfo': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMStorageQuota': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMStyleMedia': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMStyleSheet': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMStyleSheetList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMText': [ 'WebKit.DOMCharacterData', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMTextTrack': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMTextTrackCue': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMTextTrackCueList': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMTextTrackList': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMTimeRanges': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMTouch': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMTrackEvent': [ 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMTreeWalker': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMUIEvent': [ 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMValidityState': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMVideoPlaybackQuality': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMVideoTrack': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMVideoTrackList': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMWebKitNamedFlow': [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ],
-    'WebKit.DOMWebKitPoint': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMWheelEvent': [ 'WebKit.DOMMouseEvent', 'WebKit.DOMUIEvent', 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMXPathExpression': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMXPathNSResolver': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.DOMXPathResult': [ 'WebKit.DOMObject', 'GObject.Object' ],
-    'WebKit.Download': [ 'GObject.Object' ],
-    'WebKit.FaviconDatabase': [ 'GObject.Object' ],
-    'WebKit.FileChooserRequest': [ 'GObject.Object' ],
-    'WebKit.GeolocationPolicyDecision': [ 'GObject.Object' ],
-    'WebKit.HitTestResult': [ 'GObject.Object' ],
-    'WebKit.IconDatabase': [ 'GObject.Object' ],
-    'WebKit.NetworkRequest': [ 'GObject.Object' ],
-    'WebKit.NetworkResponse': [ 'GObject.Object' ],
-    'WebKit.SecurityOrigin': [ 'GObject.Object' ],
-    'WebKit.SoupAuthDialog': [ 'GObject.Object', 'Soup.SessionFeature' ],
-    'WebKit.ViewportAttributes': [ 'GObject.Object' ],
-    'WebKit.WebBackForwardList': [ 'GObject.Object' ],
-    'WebKit.WebDataSource': [ 'GObject.Object' ],
-    'WebKit.WebDatabase': [ 'GObject.Object' ],
-    'WebKit.WebFrame': [ 'GObject.Object' ],
-    'WebKit.WebHistoryItem': [ 'GObject.Object' ],
-    'WebKit.WebInspector': [ 'GObject.Object' ],
-    'WebKit.WebNavigationAction': [ 'GObject.Object' ],
-    'WebKit.WebPlugin': [ 'GObject.Object' ],
-    'WebKit.WebPluginDatabase': [ 'GObject.Object' ],
-    'WebKit.WebPolicyDecision': [ 'GObject.Object' ],
-    'WebKit.WebResource': [ 'GObject.Object' ],
-    'WebKit.WebSettings': [ 'GObject.Object' ],
-    'WebKit.WebView': [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ],
-    'WebKit.WebWindowFeatures': [ 'GObject.Object' ],
-    'AppIndicator3.Indicator': [ 'GObject.Object' ],
-    'Notify.Notification': [ 'GObject.Object' ],
-}
-
-
-interface StaticNamed {
-    name: string
-}
 
 /** Casts between derived classes, performing a run-time type-check
  * and raising an exception if the cast fails. Allows casting to implemented
  * interfaces, too.
  */
-export function giCast<T>(from_: GObject.Object, to_: StaticNamed): T {
+function c<T>(to_: string, inheritanceTable: string[], from_: GObject.Object): T {
     let desc: string = from_.toString()
     let clsName: string|null = null
     for (let k of desc.split(" ")) {
@@ -697,7 +25,7 @@ export function giCast<T>(from_: GObject.Object, to_: StaticNamed): T {
             break
         }
     }
-    let toName = to_.name.replace("_", ".")
+    let toName = to_.replace("_", ".")
 
     if (toName === clsName)
         return ((from_ as any) as T)
@@ -711,4 +39,700 @@ export function giCast<T>(from_: GObject.Object, to_: StaticNamed): T {
     }
 
     throw Error("Invalid cast of " + desc + "(" + clsName + ") to " + toName)
-}    
+}
+
+
+export function Gtk_AboutDialog(from_: GObject.Object) { return c<Gtk.AboutDialog>('Gtk.AboutDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_AccelGroup(from_: GObject.Object) { return c<Gtk.AccelGroup>('Gtk.AccelGroup', [ 'GObject.Object' ], from_) }
+export function Gtk_AccelLabel(from_: GObject.Object) { return c<Gtk.AccelLabel>('Gtk.AccelLabel', [ 'Gtk.Label', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Misc', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_AccelMap(from_: GObject.Object) { return c<Gtk.AccelMap>('Gtk.AccelMap', [ 'GObject.Object' ], from_) }
+export function Gtk_Accessible(from_: GObject.Object) { return c<Gtk.Accessible>('Gtk.Accessible', [ 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Action(from_: GObject.Object) { return c<Gtk.Action>('Gtk.Action', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function Gtk_ActionBar(from_: GObject.Object) { return c<Gtk.ActionBar>('Gtk.ActionBar', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ActionGroup(from_: GObject.Object) { return c<Gtk.ActionGroup>('Gtk.ActionGroup', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function Gtk_Adjustment(from_: GObject.Object) { return c<Gtk.Adjustment>('Gtk.Adjustment', [ 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Alignment(from_: GObject.Object) { return c<Gtk.Alignment>('Gtk.Alignment', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_AppChooserButton(from_: GObject.Object) { return c<Gtk.AppChooserButton>('Gtk.AppChooserButton', [ 'Gtk.ComboBox', 'Atk.ImplementorIface', 'Gtk.AppChooser', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.CellLayout', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_AppChooserDialog(from_: GObject.Object) { return c<Gtk.AppChooserDialog>('Gtk.AppChooserDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.AppChooser', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_AppChooserWidget(from_: GObject.Object) { return c<Gtk.AppChooserWidget>('Gtk.AppChooserWidget', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.AppChooser', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Application(from_: GObject.Object) { return c<Gtk.Application>('Gtk.Application', [ 'Gio.Application', 'Gio.ActionGroup', 'Gio.ActionMap', 'GObject.Object' ], from_) }
+export function Gtk_ApplicationWindow(from_: GObject.Object) { return c<Gtk.ApplicationWindow>('Gtk.ApplicationWindow', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gio.ActionGroup', 'Gio.ActionMap', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Arrow(from_: GObject.Object) { return c<Gtk.Arrow>('Gtk.Arrow', [ 'Gtk.Misc', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ArrowAccessible(from_: GObject.Object) { return c<Gtk.ArrowAccessible>('Gtk.ArrowAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Image', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_AspectFrame(from_: GObject.Object) { return c<Gtk.AspectFrame>('Gtk.AspectFrame', [ 'Gtk.Frame', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Assistant(from_: GObject.Object) { return c<Gtk.Assistant>('Gtk.Assistant', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Bin(from_: GObject.Object) { return c<Gtk.Bin>('Gtk.Bin', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_BooleanCellAccessible(from_: GObject.Object) { return c<Gtk.BooleanCellAccessible>('Gtk.BooleanCellAccessible', [ 'Gtk.RendererCellAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.CellAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Box(from_: GObject.Object) { return c<Gtk.Box>('Gtk.Box', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Builder(from_: GObject.Object) { return c<Gtk.Builder>('Gtk.Builder', [ 'GObject.Object' ], from_) }
+export function Gtk_Button(from_: GObject.Object) { return c<Gtk.Button>('Gtk.Button', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ButtonAccessible(from_: GObject.Object) { return c<Gtk.ButtonAccessible>('Gtk.ButtonAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ButtonBox(from_: GObject.Object) { return c<Gtk.ButtonBox>('Gtk.ButtonBox', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Calendar(from_: GObject.Object) { return c<Gtk.Calendar>('Gtk.Calendar', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellAccessible(from_: GObject.Object) { return c<Gtk.CellAccessible>('Gtk.CellAccessible', [ 'Gtk.Accessible', 'Atk.Action', 'Atk.Component', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_CellArea(from_: GObject.Object) { return c<Gtk.CellArea>('Gtk.CellArea', [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'Gtk.CellLayout', 'GObject.Object' ], from_) }
+export function Gtk_CellAreaBox(from_: GObject.Object) { return c<Gtk.CellAreaBox>('Gtk.CellAreaBox', [ 'Gtk.CellArea', 'Gtk.Buildable', 'Gtk.CellLayout', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellAreaContext(from_: GObject.Object) { return c<Gtk.CellAreaContext>('Gtk.CellAreaContext', [ 'GObject.Object' ], from_) }
+export function Gtk_CellRenderer(from_: GObject.Object) { return c<Gtk.CellRenderer>('Gtk.CellRenderer', [ 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererAccel(from_: GObject.Object) { return c<Gtk.CellRendererAccel>('Gtk.CellRendererAccel', [ 'Gtk.CellRendererText', 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererCombo(from_: GObject.Object) { return c<Gtk.CellRendererCombo>('Gtk.CellRendererCombo', [ 'Gtk.CellRendererText', 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererPixbuf(from_: GObject.Object) { return c<Gtk.CellRendererPixbuf>('Gtk.CellRendererPixbuf', [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererProgress(from_: GObject.Object) { return c<Gtk.CellRendererProgress>('Gtk.CellRendererProgress', [ 'Gtk.CellRenderer', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererSpin(from_: GObject.Object) { return c<Gtk.CellRendererSpin>('Gtk.CellRendererSpin', [ 'Gtk.CellRendererText', 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererSpinner(from_: GObject.Object) { return c<Gtk.CellRendererSpinner>('Gtk.CellRendererSpinner', [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererText(from_: GObject.Object) { return c<Gtk.CellRendererText>('Gtk.CellRendererText', [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellRendererToggle(from_: GObject.Object) { return c<Gtk.CellRendererToggle>('Gtk.CellRendererToggle', [ 'Gtk.CellRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CellView(from_: GObject.Object) { return c<Gtk.CellView>('Gtk.CellView', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellLayout', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CheckButton(from_: GObject.Object) { return c<Gtk.CheckButton>('Gtk.CheckButton', [ 'Gtk.ToggleButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CheckMenuItem(from_: GObject.Object) { return c<Gtk.CheckMenuItem>('Gtk.CheckMenuItem', [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_CheckMenuItemAccessible(from_: GObject.Object) { return c<Gtk.CheckMenuItemAccessible>('Gtk.CheckMenuItemAccessible', [ 'Gtk.MenuItemAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Clipboard(from_: GObject.Object) { return c<Gtk.Clipboard>('Gtk.Clipboard', [ 'GObject.Object' ], from_) }
+export function Gtk_ColorButton(from_: GObject.Object) { return c<Gtk.ColorButton>('Gtk.ColorButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ColorChooser', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ColorChooserDialog(from_: GObject.Object) { return c<Gtk.ColorChooserDialog>('Gtk.ColorChooserDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.ColorChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ColorChooserWidget(from_: GObject.Object) { return c<Gtk.ColorChooserWidget>('Gtk.ColorChooserWidget', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.ColorChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ColorSelection(from_: GObject.Object) { return c<Gtk.ColorSelection>('Gtk.ColorSelection', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ColorSelectionDialog(from_: GObject.Object) { return c<Gtk.ColorSelectionDialog>('Gtk.ColorSelectionDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ComboBox(from_: GObject.Object) { return c<Gtk.ComboBox>('Gtk.ComboBox', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.CellLayout', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ComboBoxAccessible(from_: GObject.Object) { return c<Gtk.ComboBoxAccessible>('Gtk.ComboBoxAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ComboBoxText(from_: GObject.Object) { return c<Gtk.ComboBoxText>('Gtk.ComboBoxText', [ 'Gtk.ComboBox', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.CellLayout', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Container(from_: GObject.Object) { return c<Gtk.Container>('Gtk.Container', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ContainerAccessible(from_: GObject.Object) { return c<Gtk.ContainerAccessible>('Gtk.ContainerAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ContainerCellAccessible(from_: GObject.Object) { return c<Gtk.ContainerCellAccessible>('Gtk.ContainerCellAccessible', [ 'Gtk.CellAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_CssProvider(from_: GObject.Object) { return c<Gtk.CssProvider>('Gtk.CssProvider', [ 'GObject.Object', 'Gtk.StyleProvider' ], from_) }
+export function Gtk_Dialog(from_: GObject.Object) { return c<Gtk.Dialog>('Gtk.Dialog', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_DrawingArea(from_: GObject.Object) { return c<Gtk.DrawingArea>('Gtk.DrawingArea', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Entry(from_: GObject.Object) { return c<Gtk.Entry>('Gtk.Entry', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.Editable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_EntryAccessible(from_: GObject.Object) { return c<Gtk.EntryAccessible>('Gtk.EntryAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Action', 'Atk.Component', 'Atk.EditableText', 'Atk.Text', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_EntryBuffer(from_: GObject.Object) { return c<Gtk.EntryBuffer>('Gtk.EntryBuffer', [ 'GObject.Object' ], from_) }
+export function Gtk_EntryCompletion(from_: GObject.Object) { return c<Gtk.EntryCompletion>('Gtk.EntryCompletion', [ 'GObject.Object', 'Gtk.Buildable', 'Gtk.CellLayout' ], from_) }
+export function Gtk_EntryIconAccessible(from_: GObject.Object) { return c<Gtk.EntryIconAccessible>('Gtk.EntryIconAccessible', [ 'Atk.Object', 'Atk.Action', 'Atk.Component', 'GObject.Object' ], from_) }
+export function Gtk_EventBox(from_: GObject.Object) { return c<Gtk.EventBox>('Gtk.EventBox', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_EventController(from_: GObject.Object) { return c<Gtk.EventController>('Gtk.EventController', [ 'GObject.Object' ], from_) }
+export function Gtk_Expander(from_: GObject.Object) { return c<Gtk.Expander>('Gtk.Expander', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ExpanderAccessible(from_: GObject.Object) { return c<Gtk.ExpanderAccessible>('Gtk.ExpanderAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_FileChooserButton(from_: GObject.Object) { return c<Gtk.FileChooserButton>('Gtk.FileChooserButton', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FileChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FileChooserDialog(from_: GObject.Object) { return c<Gtk.FileChooserDialog>('Gtk.FileChooserDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FileChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FileChooserNative(from_: GObject.Object) { return c<Gtk.FileChooserNative>('Gtk.FileChooserNative', [ 'Gtk.NativeDialog', 'Gtk.FileChooser', 'GObject.Object' ], from_) }
+export function Gtk_FileChooserWidget(from_: GObject.Object) { return c<Gtk.FileChooserWidget>('Gtk.FileChooserWidget', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FileChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FileFilter(from_: GObject.Object) { return c<Gtk.FileFilter>('Gtk.FileFilter', [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'GObject.Object' ], from_) }
+export function Gtk_Fixed(from_: GObject.Object) { return c<Gtk.Fixed>('Gtk.Fixed', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FlowBox(from_: GObject.Object) { return c<Gtk.FlowBox>('Gtk.FlowBox', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FlowBoxAccessible(from_: GObject.Object) { return c<Gtk.FlowBoxAccessible>('Gtk.FlowBoxAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_FlowBoxChild(from_: GObject.Object) { return c<Gtk.FlowBoxChild>('Gtk.FlowBoxChild', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FlowBoxChildAccessible(from_: GObject.Object) { return c<Gtk.FlowBoxChildAccessible>('Gtk.FlowBoxChildAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_FontButton(from_: GObject.Object) { return c<Gtk.FontButton>('Gtk.FontButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.FontChooser', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FontChooserDialog(from_: GObject.Object) { return c<Gtk.FontChooserDialog>('Gtk.FontChooserDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FontChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FontChooserWidget(from_: GObject.Object) { return c<Gtk.FontChooserWidget>('Gtk.FontChooserWidget', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.FontChooser', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FontSelection(from_: GObject.Object) { return c<Gtk.FontSelection>('Gtk.FontSelection', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FontSelectionDialog(from_: GObject.Object) { return c<Gtk.FontSelectionDialog>('Gtk.FontSelectionDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Frame(from_: GObject.Object) { return c<Gtk.Frame>('Gtk.Frame', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_FrameAccessible(from_: GObject.Object) { return c<Gtk.FrameAccessible>('Gtk.FrameAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_GLArea(from_: GObject.Object) { return c<Gtk.GLArea>('Gtk.GLArea', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Gesture(from_: GObject.Object) { return c<Gtk.Gesture>('Gtk.Gesture', [ 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureDrag(from_: GObject.Object) { return c<Gtk.GestureDrag>('Gtk.GestureDrag', [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureLongPress(from_: GObject.Object) { return c<Gtk.GestureLongPress>('Gtk.GestureLongPress', [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureMultiPress(from_: GObject.Object) { return c<Gtk.GestureMultiPress>('Gtk.GestureMultiPress', [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GesturePan(from_: GObject.Object) { return c<Gtk.GesturePan>('Gtk.GesturePan', [ 'Gtk.GestureDrag', 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureRotate(from_: GObject.Object) { return c<Gtk.GestureRotate>('Gtk.GestureRotate', [ 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureSingle(from_: GObject.Object) { return c<Gtk.GestureSingle>('Gtk.GestureSingle', [ 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureSwipe(from_: GObject.Object) { return c<Gtk.GestureSwipe>('Gtk.GestureSwipe', [ 'Gtk.GestureSingle', 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_GestureZoom(from_: GObject.Object) { return c<Gtk.GestureZoom>('Gtk.GestureZoom', [ 'Gtk.Gesture', 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_Grid(from_: GObject.Object) { return c<Gtk.Grid>('Gtk.Grid', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HBox(from_: GObject.Object) { return c<Gtk.HBox>('Gtk.HBox', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HButtonBox(from_: GObject.Object) { return c<Gtk.HButtonBox>('Gtk.HButtonBox', [ 'Gtk.ButtonBox', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Box', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HPaned(from_: GObject.Object) { return c<Gtk.HPaned>('Gtk.HPaned', [ 'Gtk.Paned', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HSV(from_: GObject.Object) { return c<Gtk.HSV>('Gtk.HSV', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HScale(from_: GObject.Object) { return c<Gtk.HScale>('Gtk.HScale', [ 'Gtk.Scale', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HScrollbar(from_: GObject.Object) { return c<Gtk.HScrollbar>('Gtk.HScrollbar', [ 'Gtk.Scrollbar', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HSeparator(from_: GObject.Object) { return c<Gtk.HSeparator>('Gtk.HSeparator', [ 'Gtk.Separator', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HandleBox(from_: GObject.Object) { return c<Gtk.HandleBox>('Gtk.HandleBox', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_HeaderBar(from_: GObject.Object) { return c<Gtk.HeaderBar>('Gtk.HeaderBar', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_IMContext(from_: GObject.Object) { return c<Gtk.IMContext>('Gtk.IMContext', [ 'GObject.Object' ], from_) }
+export function Gtk_IMContextSimple(from_: GObject.Object) { return c<Gtk.IMContextSimple>('Gtk.IMContextSimple', [ 'Gtk.IMContext', 'GObject.Object' ], from_) }
+export function Gtk_IMMulticontext(from_: GObject.Object) { return c<Gtk.IMMulticontext>('Gtk.IMMulticontext', [ 'Gtk.IMContext', 'GObject.Object' ], from_) }
+export function Gtk_IconFactory(from_: GObject.Object) { return c<Gtk.IconFactory>('Gtk.IconFactory', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function Gtk_IconInfo(from_: GObject.Object) { return c<Gtk.IconInfo>('Gtk.IconInfo', [ 'GObject.Object' ], from_) }
+export function Gtk_IconTheme(from_: GObject.Object) { return c<Gtk.IconTheme>('Gtk.IconTheme', [ 'GObject.Object' ], from_) }
+export function Gtk_IconView(from_: GObject.Object) { return c<Gtk.IconView>('Gtk.IconView', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellLayout', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_IconViewAccessible(from_: GObject.Object) { return c<Gtk.IconViewAccessible>('Gtk.IconViewAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Image(from_: GObject.Object) { return c<Gtk.Image>('Gtk.Image', [ 'Gtk.Misc', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ImageAccessible(from_: GObject.Object) { return c<Gtk.ImageAccessible>('Gtk.ImageAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Image', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ImageCellAccessible(from_: GObject.Object) { return c<Gtk.ImageCellAccessible>('Gtk.ImageCellAccessible', [ 'Gtk.RendererCellAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.CellAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ImageMenuItem(from_: GObject.Object) { return c<Gtk.ImageMenuItem>('Gtk.ImageMenuItem', [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_InfoBar(from_: GObject.Object) { return c<Gtk.InfoBar>('Gtk.InfoBar', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Invisible(from_: GObject.Object) { return c<Gtk.Invisible>('Gtk.Invisible', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Label(from_: GObject.Object) { return c<Gtk.Label>('Gtk.Label', [ 'Gtk.Misc', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_LabelAccessible(from_: GObject.Object) { return c<Gtk.LabelAccessible>('Gtk.LabelAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Hypertext', 'Atk.Text', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Layout(from_: GObject.Object) { return c<Gtk.Layout>('Gtk.Layout', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_LevelBar(from_: GObject.Object) { return c<Gtk.LevelBar>('Gtk.LevelBar', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_LevelBarAccessible(from_: GObject.Object) { return c<Gtk.LevelBarAccessible>('Gtk.LevelBarAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_LinkButton(from_: GObject.Object) { return c<Gtk.LinkButton>('Gtk.LinkButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_LinkButtonAccessible(from_: GObject.Object) { return c<Gtk.LinkButtonAccessible>('Gtk.LinkButtonAccessible', [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.HyperlinkImpl', 'Atk.Image', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ListBox(from_: GObject.Object) { return c<Gtk.ListBox>('Gtk.ListBox', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ListBoxAccessible(from_: GObject.Object) { return c<Gtk.ListBoxAccessible>('Gtk.ListBoxAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ListBoxRow(from_: GObject.Object) { return c<Gtk.ListBoxRow>('Gtk.ListBoxRow', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ListBoxRowAccessible(from_: GObject.Object) { return c<Gtk.ListBoxRowAccessible>('Gtk.ListBoxRowAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ListStore(from_: GObject.Object) { return c<Gtk.ListStore>('Gtk.ListStore', [ 'GObject.Object', 'Gtk.Buildable', 'Gtk.TreeDragDest', 'Gtk.TreeDragSource', 'Gtk.TreeModel', 'Gtk.TreeSortable' ], from_) }
+export function Gtk_LockButton(from_: GObject.Object) { return c<Gtk.LockButton>('Gtk.LockButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_LockButtonAccessible(from_: GObject.Object) { return c<Gtk.LockButtonAccessible>('Gtk.LockButtonAccessible', [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Menu(from_: GObject.Object) { return c<Gtk.Menu>('Gtk.Menu', [ 'Gtk.MenuShell', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MenuAccessible(from_: GObject.Object) { return c<Gtk.MenuAccessible>('Gtk.MenuAccessible', [ 'Gtk.MenuShellAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_MenuBar(from_: GObject.Object) { return c<Gtk.MenuBar>('Gtk.MenuBar', [ 'Gtk.MenuShell', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MenuButton(from_: GObject.Object) { return c<Gtk.MenuButton>('Gtk.MenuButton', [ 'Gtk.ToggleButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MenuButtonAccessible(from_: GObject.Object) { return c<Gtk.MenuButtonAccessible>('Gtk.MenuButtonAccessible', [ 'Gtk.ToggleButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ButtonAccessible', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_MenuItem(from_: GObject.Object) { return c<Gtk.MenuItem>('Gtk.MenuItem', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MenuItemAccessible(from_: GObject.Object) { return c<Gtk.MenuItemAccessible>('Gtk.MenuItemAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_MenuShell(from_: GObject.Object) { return c<Gtk.MenuShell>('Gtk.MenuShell', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MenuShellAccessible(from_: GObject.Object) { return c<Gtk.MenuShellAccessible>('Gtk.MenuShellAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_MenuToolButton(from_: GObject.Object) { return c<Gtk.MenuToolButton>('Gtk.MenuToolButton', [ 'Gtk.ToolButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToolItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MessageDialog(from_: GObject.Object) { return c<Gtk.MessageDialog>('Gtk.MessageDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Misc(from_: GObject.Object) { return c<Gtk.Misc>('Gtk.Misc', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ModelButton(from_: GObject.Object) { return c<Gtk.ModelButton>('Gtk.ModelButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_MountOperation(from_: GObject.Object) { return c<Gtk.MountOperation>('Gtk.MountOperation', [ 'Gio.MountOperation', 'GObject.Object' ], from_) }
+export function Gtk_NativeDialog(from_: GObject.Object) { return c<Gtk.NativeDialog>('Gtk.NativeDialog', [ 'GObject.Object' ], from_) }
+export function Gtk_Notebook(from_: GObject.Object) { return c<Gtk.Notebook>('Gtk.Notebook', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_NotebookAccessible(from_: GObject.Object) { return c<Gtk.NotebookAccessible>('Gtk.NotebookAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_NotebookPageAccessible(from_: GObject.Object) { return c<Gtk.NotebookPageAccessible>('Gtk.NotebookPageAccessible', [ 'Atk.Object', 'Atk.Component', 'GObject.Object' ], from_) }
+export function Gtk_NumerableIcon(from_: GObject.Object) { return c<Gtk.NumerableIcon>('Gtk.NumerableIcon', [ 'Gio.EmblemedIcon', 'Gio.Icon', 'GObject.Object' ], from_) }
+export function Gtk_OffscreenWindow(from_: GObject.Object) { return c<Gtk.OffscreenWindow>('Gtk.OffscreenWindow', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Overlay(from_: GObject.Object) { return c<Gtk.Overlay>('Gtk.Overlay', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_PadController(from_: GObject.Object) { return c<Gtk.PadController>('Gtk.PadController', [ 'Gtk.EventController', 'GObject.Object' ], from_) }
+export function Gtk_PageSetup(from_: GObject.Object) { return c<Gtk.PageSetup>('Gtk.PageSetup', [ 'GObject.Object' ], from_) }
+export function Gtk_Paned(from_: GObject.Object) { return c<Gtk.Paned>('Gtk.Paned', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_PanedAccessible(from_: GObject.Object) { return c<Gtk.PanedAccessible>('Gtk.PanedAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_PlacesSidebar(from_: GObject.Object) { return c<Gtk.PlacesSidebar>('Gtk.PlacesSidebar', [ 'Gtk.ScrolledWindow', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Plug(from_: GObject.Object) { return c<Gtk.Plug>('Gtk.Plug', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Popover(from_: GObject.Object) { return c<Gtk.Popover>('Gtk.Popover', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_PopoverAccessible(from_: GObject.Object) { return c<Gtk.PopoverAccessible>('Gtk.PopoverAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_PopoverMenu(from_: GObject.Object) { return c<Gtk.PopoverMenu>('Gtk.PopoverMenu', [ 'Gtk.Popover', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_PrintContext(from_: GObject.Object) { return c<Gtk.PrintContext>('Gtk.PrintContext', [ 'GObject.Object' ], from_) }
+export function Gtk_PrintOperation(from_: GObject.Object) { return c<Gtk.PrintOperation>('Gtk.PrintOperation', [ 'GObject.Object', 'Gtk.PrintOperationPreview' ], from_) }
+export function Gtk_PrintSettings(from_: GObject.Object) { return c<Gtk.PrintSettings>('Gtk.PrintSettings', [ 'GObject.Object' ], from_) }
+export function Gtk_ProgressBar(from_: GObject.Object) { return c<Gtk.ProgressBar>('Gtk.ProgressBar', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ProgressBarAccessible(from_: GObject.Object) { return c<Gtk.ProgressBarAccessible>('Gtk.ProgressBarAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_RadioAction(from_: GObject.Object) { return c<Gtk.RadioAction>('Gtk.RadioAction', [ 'Gtk.ToggleAction', 'Gtk.Buildable', 'Gtk.Action', 'GObject.Object' ], from_) }
+export function Gtk_RadioButton(from_: GObject.Object) { return c<Gtk.RadioButton>('Gtk.RadioButton', [ 'Gtk.CheckButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToggleButton', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_RadioButtonAccessible(from_: GObject.Object) { return c<Gtk.RadioButtonAccessible>('Gtk.RadioButtonAccessible', [ 'Gtk.ToggleButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ButtonAccessible', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_RadioMenuItem(from_: GObject.Object) { return c<Gtk.RadioMenuItem>('Gtk.RadioMenuItem', [ 'Gtk.CheckMenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.MenuItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_RadioMenuItemAccessible(from_: GObject.Object) { return c<Gtk.RadioMenuItemAccessible>('Gtk.RadioMenuItemAccessible', [ 'Gtk.CheckMenuItemAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Selection', 'Gtk.MenuItemAccessible', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_RadioToolButton(from_: GObject.Object) { return c<Gtk.RadioToolButton>('Gtk.RadioToolButton', [ 'Gtk.ToggleToolButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToolButton', 'Gtk.ToolItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Range(from_: GObject.Object) { return c<Gtk.Range>('Gtk.Range', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_RangeAccessible(from_: GObject.Object) { return c<Gtk.RangeAccessible>('Gtk.RangeAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_RcStyle(from_: GObject.Object) { return c<Gtk.RcStyle>('Gtk.RcStyle', [ 'GObject.Object' ], from_) }
+export function Gtk_RecentAction(from_: GObject.Object) { return c<Gtk.RecentAction>('Gtk.RecentAction', [ 'Gtk.Action', 'Gtk.Buildable', 'Gtk.RecentChooser', 'GObject.Object' ], from_) }
+export function Gtk_RecentChooserDialog(from_: GObject.Object) { return c<Gtk.RecentChooserDialog>('Gtk.RecentChooserDialog', [ 'Gtk.Dialog', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.RecentChooser', 'Gtk.Window', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_RecentChooserMenu(from_: GObject.Object) { return c<Gtk.RecentChooserMenu>('Gtk.RecentChooserMenu', [ 'Gtk.Menu', 'Atk.ImplementorIface', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.RecentChooser', 'Gtk.MenuShell', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_RecentChooserWidget(from_: GObject.Object) { return c<Gtk.RecentChooserWidget>('Gtk.RecentChooserWidget', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.RecentChooser', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_RecentFilter(from_: GObject.Object) { return c<Gtk.RecentFilter>('Gtk.RecentFilter', [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'GObject.Object' ], from_) }
+export function Gtk_RecentManager(from_: GObject.Object) { return c<Gtk.RecentManager>('Gtk.RecentManager', [ 'GObject.Object' ], from_) }
+export function Gtk_RendererCellAccessible(from_: GObject.Object) { return c<Gtk.RendererCellAccessible>('Gtk.RendererCellAccessible', [ 'Gtk.CellAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Revealer(from_: GObject.Object) { return c<Gtk.Revealer>('Gtk.Revealer', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Scale(from_: GObject.Object) { return c<Gtk.Scale>('Gtk.Scale', [ 'Gtk.Range', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ScaleAccessible(from_: GObject.Object) { return c<Gtk.ScaleAccessible>('Gtk.ScaleAccessible', [ 'Gtk.RangeAccessible', 'Atk.Component', 'Atk.Value', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ScaleButton(from_: GObject.Object) { return c<Gtk.ScaleButton>('Gtk.ScaleButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ScaleButtonAccessible(from_: GObject.Object) { return c<Gtk.ScaleButtonAccessible>('Gtk.ScaleButtonAccessible', [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Atk.Value', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Scrollbar(from_: GObject.Object) { return c<Gtk.Scrollbar>('Gtk.Scrollbar', [ 'Gtk.Range', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ScrolledWindow(from_: GObject.Object) { return c<Gtk.ScrolledWindow>('Gtk.ScrolledWindow', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ScrolledWindowAccessible(from_: GObject.Object) { return c<Gtk.ScrolledWindowAccessible>('Gtk.ScrolledWindowAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_SearchBar(from_: GObject.Object) { return c<Gtk.SearchBar>('Gtk.SearchBar', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SearchEntry(from_: GObject.Object) { return c<Gtk.SearchEntry>('Gtk.SearchEntry', [ 'Gtk.Entry', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.Editable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Separator(from_: GObject.Object) { return c<Gtk.Separator>('Gtk.Separator', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SeparatorMenuItem(from_: GObject.Object) { return c<Gtk.SeparatorMenuItem>('Gtk.SeparatorMenuItem', [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SeparatorToolItem(from_: GObject.Object) { return c<Gtk.SeparatorToolItem>('Gtk.SeparatorToolItem', [ 'Gtk.ToolItem', 'Atk.ImplementorIface', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Settings(from_: GObject.Object) { return c<Gtk.Settings>('Gtk.Settings', [ 'GObject.Object', 'Gtk.StyleProvider' ], from_) }
+export function Gtk_ShortcutLabel(from_: GObject.Object) { return c<Gtk.ShortcutLabel>('Gtk.ShortcutLabel', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ShortcutsGroup(from_: GObject.Object) { return c<Gtk.ShortcutsGroup>('Gtk.ShortcutsGroup', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ShortcutsSection(from_: GObject.Object) { return c<Gtk.ShortcutsSection>('Gtk.ShortcutsSection', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ShortcutsShortcut(from_: GObject.Object) { return c<Gtk.ShortcutsShortcut>('Gtk.ShortcutsShortcut', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ShortcutsWindow(from_: GObject.Object) { return c<Gtk.ShortcutsWindow>('Gtk.ShortcutsWindow', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SizeGroup(from_: GObject.Object) { return c<Gtk.SizeGroup>('Gtk.SizeGroup', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function Gtk_Socket(from_: GObject.Object) { return c<Gtk.Socket>('Gtk.Socket', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SpinButton(from_: GObject.Object) { return c<Gtk.SpinButton>('Gtk.SpinButton', [ 'Gtk.Entry', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.CellEditable', 'Gtk.Editable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SpinButtonAccessible(from_: GObject.Object) { return c<Gtk.SpinButtonAccessible>('Gtk.SpinButtonAccessible', [ 'Gtk.EntryAccessible', 'Atk.Action', 'Atk.Component', 'Atk.EditableText', 'Atk.Text', 'Atk.Value', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Spinner(from_: GObject.Object) { return c<Gtk.Spinner>('Gtk.Spinner', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SpinnerAccessible(from_: GObject.Object) { return c<Gtk.SpinnerAccessible>('Gtk.SpinnerAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Component', 'Atk.Image', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Stack(from_: GObject.Object) { return c<Gtk.Stack>('Gtk.Stack', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_StackAccessible(from_: GObject.Object) { return c<Gtk.StackAccessible>('Gtk.StackAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_StackSidebar(from_: GObject.Object) { return c<Gtk.StackSidebar>('Gtk.StackSidebar', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_StackSwitcher(from_: GObject.Object) { return c<Gtk.StackSwitcher>('Gtk.StackSwitcher', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_StatusIcon(from_: GObject.Object) { return c<Gtk.StatusIcon>('Gtk.StatusIcon', [ 'GObject.Object' ], from_) }
+export function Gtk_Statusbar(from_: GObject.Object) { return c<Gtk.Statusbar>('Gtk.Statusbar', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_StatusbarAccessible(from_: GObject.Object) { return c<Gtk.StatusbarAccessible>('Gtk.StatusbarAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Style(from_: GObject.Object) { return c<Gtk.Style>('Gtk.Style', [ 'GObject.Object' ], from_) }
+export function Gtk_StyleContext(from_: GObject.Object) { return c<Gtk.StyleContext>('Gtk.StyleContext', [ 'GObject.Object' ], from_) }
+export function Gtk_StyleProperties(from_: GObject.Object) { return c<Gtk.StyleProperties>('Gtk.StyleProperties', [ 'GObject.Object', 'Gtk.StyleProvider' ], from_) }
+export function Gtk_Switch(from_: GObject.Object) { return c<Gtk.Switch>('Gtk.Switch', [ 'Gtk.Widget', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_SwitchAccessible(from_: GObject.Object) { return c<Gtk.SwitchAccessible>('Gtk.SwitchAccessible', [ 'Gtk.WidgetAccessible', 'Atk.Action', 'Atk.Component', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Table(from_: GObject.Object) { return c<Gtk.Table>('Gtk.Table', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_TearoffMenuItem(from_: GObject.Object) { return c<Gtk.TearoffMenuItem>('Gtk.TearoffMenuItem', [ 'Gtk.MenuItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_TextBuffer(from_: GObject.Object) { return c<Gtk.TextBuffer>('Gtk.TextBuffer', [ 'GObject.Object' ], from_) }
+export function Gtk_TextCellAccessible(from_: GObject.Object) { return c<Gtk.TextCellAccessible>('Gtk.TextCellAccessible', [ 'Gtk.RendererCellAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Text', 'Gtk.CellAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_TextChildAnchor(from_: GObject.Object) { return c<Gtk.TextChildAnchor>('Gtk.TextChildAnchor', [ 'GObject.Object' ], from_) }
+export function Gtk_TextMark(from_: GObject.Object) { return c<Gtk.TextMark>('Gtk.TextMark', [ 'GObject.Object' ], from_) }
+export function Gtk_TextTag(from_: GObject.Object) { return c<Gtk.TextTag>('Gtk.TextTag', [ 'GObject.Object' ], from_) }
+export function Gtk_TextTagTable(from_: GObject.Object) { return c<Gtk.TextTagTable>('Gtk.TextTagTable', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function Gtk_TextView(from_: GObject.Object) { return c<Gtk.TextView>('Gtk.TextView', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_TextViewAccessible(from_: GObject.Object) { return c<Gtk.TextViewAccessible>('Gtk.TextViewAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.EditableText', 'Atk.StreamableContent', 'Atk.Text', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ThemingEngine(from_: GObject.Object) { return c<Gtk.ThemingEngine>('Gtk.ThemingEngine', [ 'GObject.Object' ], from_) }
+export function Gtk_ToggleAction(from_: GObject.Object) { return c<Gtk.ToggleAction>('Gtk.ToggleAction', [ 'Gtk.Action', 'Gtk.Buildable', 'GObject.Object' ], from_) }
+export function Gtk_ToggleButton(from_: GObject.Object) { return c<Gtk.ToggleButton>('Gtk.ToggleButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ToggleButtonAccessible(from_: GObject.Object) { return c<Gtk.ToggleButtonAccessible>('Gtk.ToggleButtonAccessible', [ 'Gtk.ButtonAccessible', 'Atk.Action', 'Atk.Component', 'Atk.Image', 'Gtk.ContainerAccessible', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_ToggleToolButton(from_: GObject.Object) { return c<Gtk.ToggleToolButton>('Gtk.ToggleToolButton', [ 'Gtk.ToolButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.ToolItem', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ToolButton(from_: GObject.Object) { return c<Gtk.ToolButton>('Gtk.ToolButton', [ 'Gtk.ToolItem', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ToolItem(from_: GObject.Object) { return c<Gtk.ToolItem>('Gtk.ToolItem', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ToolItemGroup(from_: GObject.Object) { return c<Gtk.ToolItemGroup>('Gtk.ToolItemGroup', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.ToolShell', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_ToolPalette(from_: GObject.Object) { return c<Gtk.ToolPalette>('Gtk.ToolPalette', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Toolbar(from_: GObject.Object) { return c<Gtk.Toolbar>('Gtk.Toolbar', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.ToolShell', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Tooltip(from_: GObject.Object) { return c<Gtk.Tooltip>('Gtk.Tooltip', [ 'GObject.Object' ], from_) }
+export function Gtk_ToplevelAccessible(from_: GObject.Object) { return c<Gtk.ToplevelAccessible>('Gtk.ToplevelAccessible', [ 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_TreeModelFilter(from_: GObject.Object) { return c<Gtk.TreeModelFilter>('Gtk.TreeModelFilter', [ 'GObject.Object', 'Gtk.TreeDragSource', 'Gtk.TreeModel' ], from_) }
+export function Gtk_TreeModelSort(from_: GObject.Object) { return c<Gtk.TreeModelSort>('Gtk.TreeModelSort', [ 'GObject.Object', 'Gtk.TreeDragSource', 'Gtk.TreeModel', 'Gtk.TreeSortable' ], from_) }
+export function Gtk_TreeSelection(from_: GObject.Object) { return c<Gtk.TreeSelection>('Gtk.TreeSelection', [ 'GObject.Object' ], from_) }
+export function Gtk_TreeStore(from_: GObject.Object) { return c<Gtk.TreeStore>('Gtk.TreeStore', [ 'GObject.Object', 'Gtk.Buildable', 'Gtk.TreeDragDest', 'Gtk.TreeDragSource', 'Gtk.TreeModel', 'Gtk.TreeSortable' ], from_) }
+export function Gtk_TreeView(from_: GObject.Object) { return c<Gtk.TreeView>('Gtk.TreeView', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_TreeViewAccessible(from_: GObject.Object) { return c<Gtk.TreeViewAccessible>('Gtk.TreeViewAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Selection', 'Atk.Table', 'Gtk.CellAccessibleParent', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_TreeViewColumn(from_: GObject.Object) { return c<Gtk.TreeViewColumn>('Gtk.TreeViewColumn', [ 'GObject.InitiallyUnowned', 'Gtk.Buildable', 'Gtk.CellLayout', 'GObject.Object' ], from_) }
+export function Gtk_UIManager(from_: GObject.Object) { return c<Gtk.UIManager>('Gtk.UIManager', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function Gtk_VBox(from_: GObject.Object) { return c<Gtk.VBox>('Gtk.VBox', [ 'Gtk.Box', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_VButtonBox(from_: GObject.Object) { return c<Gtk.VButtonBox>('Gtk.VButtonBox', [ 'Gtk.ButtonBox', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Box', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_VPaned(from_: GObject.Object) { return c<Gtk.VPaned>('Gtk.VPaned', [ 'Gtk.Paned', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_VScale(from_: GObject.Object) { return c<Gtk.VScale>('Gtk.VScale', [ 'Gtk.Scale', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_VScrollbar(from_: GObject.Object) { return c<Gtk.VScrollbar>('Gtk.VScrollbar', [ 'Gtk.Scrollbar', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Range', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_VSeparator(from_: GObject.Object) { return c<Gtk.VSeparator>('Gtk.VSeparator', [ 'Gtk.Separator', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Viewport(from_: GObject.Object) { return c<Gtk.Viewport>('Gtk.Viewport', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_VolumeButton(from_: GObject.Object) { return c<Gtk.VolumeButton>('Gtk.VolumeButton', [ 'Gtk.ScaleButton', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'Gtk.Orientable', 'Gtk.Button', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_Widget(from_: GObject.Object) { return c<Gtk.Widget>('Gtk.Widget', [ 'GObject.InitiallyUnowned', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GObject.Object' ], from_) }
+export function Gtk_WidgetAccessible(from_: GObject.Object) { return c<Gtk.WidgetAccessible>('Gtk.WidgetAccessible', [ 'Gtk.Accessible', 'Atk.Component', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_Window(from_: GObject.Object) { return c<Gtk.Window>('Gtk.Window', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function Gtk_WindowAccessible(from_: GObject.Object) { return c<Gtk.WindowAccessible>('Gtk.WindowAccessible', [ 'Gtk.ContainerAccessible', 'Atk.Component', 'Atk.Window', 'Gtk.WidgetAccessible', 'Gtk.Accessible', 'Atk.Object', 'GObject.Object' ], from_) }
+export function Gtk_WindowGroup(from_: GObject.Object) { return c<Gtk.WindowGroup>('Gtk.WindowGroup', [ 'GObject.Object' ], from_) }
+export function Atk_GObjectAccessible(from_: GObject.Object) { return c<Atk.GObjectAccessible>('Atk.GObjectAccessible', [ 'Atk.Object', 'GObject.Object' ], from_) }
+export function Atk_Hyperlink(from_: GObject.Object) { return c<Atk.Hyperlink>('Atk.Hyperlink', [ 'GObject.Object', 'Atk.Action' ], from_) }
+export function Atk_Misc(from_: GObject.Object) { return c<Atk.Misc>('Atk.Misc', [ 'GObject.Object' ], from_) }
+export function Atk_NoOpObject(from_: GObject.Object) { return c<Atk.NoOpObject>('Atk.NoOpObject', [ 'Atk.Object', 'Atk.Action', 'Atk.Component', 'Atk.Document', 'Atk.EditableText', 'Atk.Hypertext', 'Atk.Image', 'Atk.Selection', 'Atk.Table', 'Atk.TableCell', 'Atk.Text', 'Atk.Value', 'Atk.Window', 'GObject.Object' ], from_) }
+export function Atk_NoOpObjectFactory(from_: GObject.Object) { return c<Atk.NoOpObjectFactory>('Atk.NoOpObjectFactory', [ 'Atk.ObjectFactory', 'GObject.Object' ], from_) }
+export function Atk_Object(from_: GObject.Object) { return c<Atk.Object>('Atk.Object', [ 'GObject.Object' ], from_) }
+export function Atk_ObjectFactory(from_: GObject.Object) { return c<Atk.ObjectFactory>('Atk.ObjectFactory', [ 'GObject.Object' ], from_) }
+export function Atk_Plug(from_: GObject.Object) { return c<Atk.Plug>('Atk.Plug', [ 'Atk.Object', 'Atk.Component', 'GObject.Object' ], from_) }
+export function Atk_Registry(from_: GObject.Object) { return c<Atk.Registry>('Atk.Registry', [ 'GObject.Object' ], from_) }
+export function Atk_Relation(from_: GObject.Object) { return c<Atk.Relation>('Atk.Relation', [ 'GObject.Object' ], from_) }
+export function Atk_RelationSet(from_: GObject.Object) { return c<Atk.RelationSet>('Atk.RelationSet', [ 'GObject.Object' ], from_) }
+export function Atk_Socket(from_: GObject.Object) { return c<Atk.Socket>('Atk.Socket', [ 'Atk.Object', 'Atk.Component', 'GObject.Object' ], from_) }
+export function Atk_StateSet(from_: GObject.Object) { return c<Atk.StateSet>('Atk.StateSet', [ 'GObject.Object' ], from_) }
+export function Atk_Util(from_: GObject.Object) { return c<Atk.Util>('Atk.Util', [ 'GObject.Object' ], from_) }
+export function GObject_Binding(from_: GObject.Object) { return c<GObject.Binding>('GObject.Binding', [ 'GObject.Object' ], from_) }
+export function GObject_InitiallyUnowned(from_: GObject.Object) { return c<GObject.InitiallyUnowned>('GObject.InitiallyUnowned', [ 'GObject.Object' ], from_) }
+export function GObject_ParamSpecBoolean(from_: GObject.Object) { return c<GObject.ParamSpecBoolean>('GObject.ParamSpecBoolean', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecBoxed(from_: GObject.Object) { return c<GObject.ParamSpecBoxed>('GObject.ParamSpecBoxed', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecChar(from_: GObject.Object) { return c<GObject.ParamSpecChar>('GObject.ParamSpecChar', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecDouble(from_: GObject.Object) { return c<GObject.ParamSpecDouble>('GObject.ParamSpecDouble', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecEnum(from_: GObject.Object) { return c<GObject.ParamSpecEnum>('GObject.ParamSpecEnum', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecFlags(from_: GObject.Object) { return c<GObject.ParamSpecFlags>('GObject.ParamSpecFlags', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecFloat(from_: GObject.Object) { return c<GObject.ParamSpecFloat>('GObject.ParamSpecFloat', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecGType(from_: GObject.Object) { return c<GObject.ParamSpecGType>('GObject.ParamSpecGType', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecInt(from_: GObject.Object) { return c<GObject.ParamSpecInt>('GObject.ParamSpecInt', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecInt64(from_: GObject.Object) { return c<GObject.ParamSpecInt64>('GObject.ParamSpecInt64', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecLong(from_: GObject.Object) { return c<GObject.ParamSpecLong>('GObject.ParamSpecLong', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecObject(from_: GObject.Object) { return c<GObject.ParamSpecObject>('GObject.ParamSpecObject', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecOverride(from_: GObject.Object) { return c<GObject.ParamSpecOverride>('GObject.ParamSpecOverride', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecParam(from_: GObject.Object) { return c<GObject.ParamSpecParam>('GObject.ParamSpecParam', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecPointer(from_: GObject.Object) { return c<GObject.ParamSpecPointer>('GObject.ParamSpecPointer', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecString(from_: GObject.Object) { return c<GObject.ParamSpecString>('GObject.ParamSpecString', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecUChar(from_: GObject.Object) { return c<GObject.ParamSpecUChar>('GObject.ParamSpecUChar', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecUInt(from_: GObject.Object) { return c<GObject.ParamSpecUInt>('GObject.ParamSpecUInt', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecUInt64(from_: GObject.Object) { return c<GObject.ParamSpecUInt64>('GObject.ParamSpecUInt64', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecULong(from_: GObject.Object) { return c<GObject.ParamSpecULong>('GObject.ParamSpecULong', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecUnichar(from_: GObject.Object) { return c<GObject.ParamSpecUnichar>('GObject.ParamSpecUnichar', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecValueArray(from_: GObject.Object) { return c<GObject.ParamSpecValueArray>('GObject.ParamSpecValueArray', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_ParamSpecVariant(from_: GObject.Object) { return c<GObject.ParamSpecVariant>('GObject.ParamSpecVariant', [ 'GObject.ParamSpec' ], from_) }
+export function GObject_TypeModule(from_: GObject.Object) { return c<GObject.TypeModule>('GObject.TypeModule', [ 'GObject.Object', 'GObject.TypePlugin' ], from_) }
+export function Gdk_AppLaunchContext(from_: GObject.Object) { return c<Gdk.AppLaunchContext>('Gdk.AppLaunchContext', [ 'Gio.AppLaunchContext', 'GObject.Object' ], from_) }
+export function Gdk_Cursor(from_: GObject.Object) { return c<Gdk.Cursor>('Gdk.Cursor', [ 'GObject.Object' ], from_) }
+export function Gdk_Device(from_: GObject.Object) { return c<Gdk.Device>('Gdk.Device', [ 'GObject.Object' ], from_) }
+export function Gdk_DeviceManager(from_: GObject.Object) { return c<Gdk.DeviceManager>('Gdk.DeviceManager', [ 'GObject.Object' ], from_) }
+export function Gdk_DeviceTool(from_: GObject.Object) { return c<Gdk.DeviceTool>('Gdk.DeviceTool', [ 'GObject.Object' ], from_) }
+export function Gdk_Display(from_: GObject.Object) { return c<Gdk.Display>('Gdk.Display', [ 'GObject.Object' ], from_) }
+export function Gdk_DisplayManager(from_: GObject.Object) { return c<Gdk.DisplayManager>('Gdk.DisplayManager', [ 'GObject.Object' ], from_) }
+export function Gdk_DragContext(from_: GObject.Object) { return c<Gdk.DragContext>('Gdk.DragContext', [ 'GObject.Object' ], from_) }
+export function Gdk_DrawingContext(from_: GObject.Object) { return c<Gdk.DrawingContext>('Gdk.DrawingContext', [ 'GObject.Object' ], from_) }
+export function Gdk_FrameClock(from_: GObject.Object) { return c<Gdk.FrameClock>('Gdk.FrameClock', [ 'GObject.Object' ], from_) }
+export function Gdk_GLContext(from_: GObject.Object) { return c<Gdk.GLContext>('Gdk.GLContext', [ 'GObject.Object' ], from_) }
+export function Gdk_Keymap(from_: GObject.Object) { return c<Gdk.Keymap>('Gdk.Keymap', [ 'GObject.Object' ], from_) }
+export function Gdk_Monitor(from_: GObject.Object) { return c<Gdk.Monitor>('Gdk.Monitor', [ 'GObject.Object' ], from_) }
+export function Gdk_Screen(from_: GObject.Object) { return c<Gdk.Screen>('Gdk.Screen', [ 'GObject.Object' ], from_) }
+export function Gdk_Seat(from_: GObject.Object) { return c<Gdk.Seat>('Gdk.Seat', [ 'GObject.Object' ], from_) }
+export function Gdk_Visual(from_: GObject.Object) { return c<Gdk.Visual>('Gdk.Visual', [ 'GObject.Object' ], from_) }
+export function Gdk_Window(from_: GObject.Object) { return c<Gdk.Window>('Gdk.Window', [ 'GObject.Object' ], from_) }
+export function GdkPixbuf_Pixbuf(from_: GObject.Object) { return c<GdkPixbuf.Pixbuf>('GdkPixbuf.Pixbuf', [ 'GObject.Object', 'Gio.Icon', 'Gio.LoadableIcon' ], from_) }
+export function GdkPixbuf_PixbufAnimation(from_: GObject.Object) { return c<GdkPixbuf.PixbufAnimation>('GdkPixbuf.PixbufAnimation', [ 'GObject.Object' ], from_) }
+export function GdkPixbuf_PixbufAnimationIter(from_: GObject.Object) { return c<GdkPixbuf.PixbufAnimationIter>('GdkPixbuf.PixbufAnimationIter', [ 'GObject.Object' ], from_) }
+export function GdkPixbuf_PixbufLoader(from_: GObject.Object) { return c<GdkPixbuf.PixbufLoader>('GdkPixbuf.PixbufLoader', [ 'GObject.Object' ], from_) }
+export function GdkPixbuf_PixbufSimpleAnim(from_: GObject.Object) { return c<GdkPixbuf.PixbufSimpleAnim>('GdkPixbuf.PixbufSimpleAnim', [ 'GdkPixbuf.PixbufAnimation', 'GObject.Object' ], from_) }
+export function GdkPixbuf_PixbufSimpleAnimIter(from_: GObject.Object) { return c<GdkPixbuf.PixbufSimpleAnimIter>('GdkPixbuf.PixbufSimpleAnimIter', [ 'GdkPixbuf.PixbufAnimationIter', 'GObject.Object' ], from_) }
+export function Gio_AppInfoMonitor(from_: GObject.Object) { return c<Gio.AppInfoMonitor>('Gio.AppInfoMonitor', [ 'GObject.Object' ], from_) }
+export function Gio_AppLaunchContext(from_: GObject.Object) { return c<Gio.AppLaunchContext>('Gio.AppLaunchContext', [ 'GObject.Object' ], from_) }
+export function Gio_Application(from_: GObject.Object) { return c<Gio.Application>('Gio.Application', [ 'GObject.Object', 'Gio.ActionGroup', 'Gio.ActionMap' ], from_) }
+export function Gio_ApplicationCommandLine(from_: GObject.Object) { return c<Gio.ApplicationCommandLine>('Gio.ApplicationCommandLine', [ 'GObject.Object' ], from_) }
+export function Gio_BufferedInputStream(from_: GObject.Object) { return c<Gio.BufferedInputStream>('Gio.BufferedInputStream', [ 'Gio.FilterInputStream', 'Gio.Seekable', 'Gio.InputStream', 'GObject.Object' ], from_) }
+export function Gio_BufferedOutputStream(from_: GObject.Object) { return c<Gio.BufferedOutputStream>('Gio.BufferedOutputStream', [ 'Gio.FilterOutputStream', 'Gio.Seekable', 'Gio.OutputStream', 'GObject.Object' ], from_) }
+export function Gio_BytesIcon(from_: GObject.Object) { return c<Gio.BytesIcon>('Gio.BytesIcon', [ 'GObject.Object', 'Gio.Icon', 'Gio.LoadableIcon' ], from_) }
+export function Gio_Cancellable(from_: GObject.Object) { return c<Gio.Cancellable>('Gio.Cancellable', [ 'GObject.Object' ], from_) }
+export function Gio_CharsetConverter(from_: GObject.Object) { return c<Gio.CharsetConverter>('Gio.CharsetConverter', [ 'GObject.Object', 'Gio.Converter', 'Gio.Initable' ], from_) }
+export function Gio_ConverterInputStream(from_: GObject.Object) { return c<Gio.ConverterInputStream>('Gio.ConverterInputStream', [ 'Gio.FilterInputStream', 'Gio.PollableInputStream', 'Gio.InputStream', 'GObject.Object' ], from_) }
+export function Gio_ConverterOutputStream(from_: GObject.Object) { return c<Gio.ConverterOutputStream>('Gio.ConverterOutputStream', [ 'Gio.FilterOutputStream', 'Gio.PollableOutputStream', 'Gio.OutputStream', 'GObject.Object' ], from_) }
+export function Gio_Credentials(from_: GObject.Object) { return c<Gio.Credentials>('Gio.Credentials', [ 'GObject.Object' ], from_) }
+export function Gio_DBusActionGroup(from_: GObject.Object) { return c<Gio.DBusActionGroup>('Gio.DBusActionGroup', [ 'GObject.Object', 'Gio.ActionGroup', 'Gio.RemoteActionGroup' ], from_) }
+export function Gio_DBusAuthObserver(from_: GObject.Object) { return c<Gio.DBusAuthObserver>('Gio.DBusAuthObserver', [ 'GObject.Object' ], from_) }
+export function Gio_DBusConnection(from_: GObject.Object) { return c<Gio.DBusConnection>('Gio.DBusConnection', [ 'GObject.Object', 'Gio.AsyncInitable', 'Gio.Initable' ], from_) }
+export function Gio_DBusInterfaceSkeleton(from_: GObject.Object) { return c<Gio.DBusInterfaceSkeleton>('Gio.DBusInterfaceSkeleton', [ 'GObject.Object', 'Gio.DBusInterface' ], from_) }
+export function Gio_DBusMenuModel(from_: GObject.Object) { return c<Gio.DBusMenuModel>('Gio.DBusMenuModel', [ 'Gio.MenuModel', 'GObject.Object' ], from_) }
+export function Gio_DBusMessage(from_: GObject.Object) { return c<Gio.DBusMessage>('Gio.DBusMessage', [ 'GObject.Object' ], from_) }
+export function Gio_DBusMethodInvocation(from_: GObject.Object) { return c<Gio.DBusMethodInvocation>('Gio.DBusMethodInvocation', [ 'GObject.Object' ], from_) }
+export function Gio_DBusObjectManagerClient(from_: GObject.Object) { return c<Gio.DBusObjectManagerClient>('Gio.DBusObjectManagerClient', [ 'GObject.Object', 'Gio.AsyncInitable', 'Gio.DBusObjectManager', 'Gio.Initable' ], from_) }
+export function Gio_DBusObjectManagerServer(from_: GObject.Object) { return c<Gio.DBusObjectManagerServer>('Gio.DBusObjectManagerServer', [ 'GObject.Object', 'Gio.DBusObjectManager' ], from_) }
+export function Gio_DBusObjectProxy(from_: GObject.Object) { return c<Gio.DBusObjectProxy>('Gio.DBusObjectProxy', [ 'GObject.Object', 'Gio.DBusObject' ], from_) }
+export function Gio_DBusObjectSkeleton(from_: GObject.Object) { return c<Gio.DBusObjectSkeleton>('Gio.DBusObjectSkeleton', [ 'GObject.Object', 'Gio.DBusObject' ], from_) }
+export function Gio_DBusProxy(from_: GObject.Object) { return c<Gio.DBusProxy>('Gio.DBusProxy', [ 'GObject.Object', 'Gio.AsyncInitable', 'Gio.DBusInterface', 'Gio.Initable' ], from_) }
+export function Gio_DBusServer(from_: GObject.Object) { return c<Gio.DBusServer>('Gio.DBusServer', [ 'GObject.Object', 'Gio.Initable' ], from_) }
+export function Gio_DataInputStream(from_: GObject.Object) { return c<Gio.DataInputStream>('Gio.DataInputStream', [ 'Gio.BufferedInputStream', 'Gio.Seekable', 'Gio.FilterInputStream', 'Gio.InputStream', 'GObject.Object' ], from_) }
+export function Gio_DataOutputStream(from_: GObject.Object) { return c<Gio.DataOutputStream>('Gio.DataOutputStream', [ 'Gio.FilterOutputStream', 'Gio.Seekable', 'Gio.OutputStream', 'GObject.Object' ], from_) }
+export function Gio_DesktopAppInfo(from_: GObject.Object) { return c<Gio.DesktopAppInfo>('Gio.DesktopAppInfo', [ 'GObject.Object', 'Gio.AppInfo' ], from_) }
+export function Gio_Emblem(from_: GObject.Object) { return c<Gio.Emblem>('Gio.Emblem', [ 'GObject.Object', 'Gio.Icon' ], from_) }
+export function Gio_EmblemedIcon(from_: GObject.Object) { return c<Gio.EmblemedIcon>('Gio.EmblemedIcon', [ 'GObject.Object', 'Gio.Icon' ], from_) }
+export function Gio_FileEnumerator(from_: GObject.Object) { return c<Gio.FileEnumerator>('Gio.FileEnumerator', [ 'GObject.Object' ], from_) }
+export function Gio_FileIOStream(from_: GObject.Object) { return c<Gio.FileIOStream>('Gio.FileIOStream', [ 'Gio.IOStream', 'Gio.Seekable', 'GObject.Object' ], from_) }
+export function Gio_FileIcon(from_: GObject.Object) { return c<Gio.FileIcon>('Gio.FileIcon', [ 'GObject.Object', 'Gio.Icon', 'Gio.LoadableIcon' ], from_) }
+export function Gio_FileInfo(from_: GObject.Object) { return c<Gio.FileInfo>('Gio.FileInfo', [ 'GObject.Object' ], from_) }
+export function Gio_FileInputStream(from_: GObject.Object) { return c<Gio.FileInputStream>('Gio.FileInputStream', [ 'Gio.InputStream', 'Gio.Seekable', 'GObject.Object' ], from_) }
+export function Gio_FileMonitor(from_: GObject.Object) { return c<Gio.FileMonitor>('Gio.FileMonitor', [ 'GObject.Object' ], from_) }
+export function Gio_FileOutputStream(from_: GObject.Object) { return c<Gio.FileOutputStream>('Gio.FileOutputStream', [ 'Gio.OutputStream', 'Gio.Seekable', 'GObject.Object' ], from_) }
+export function Gio_FilenameCompleter(from_: GObject.Object) { return c<Gio.FilenameCompleter>('Gio.FilenameCompleter', [ 'GObject.Object' ], from_) }
+export function Gio_FilterInputStream(from_: GObject.Object) { return c<Gio.FilterInputStream>('Gio.FilterInputStream', [ 'Gio.InputStream', 'GObject.Object' ], from_) }
+export function Gio_FilterOutputStream(from_: GObject.Object) { return c<Gio.FilterOutputStream>('Gio.FilterOutputStream', [ 'Gio.OutputStream', 'GObject.Object' ], from_) }
+export function Gio_IOModule(from_: GObject.Object) { return c<Gio.IOModule>('Gio.IOModule', [ 'GObject.TypeModule', 'GObject.TypePlugin', 'GObject.Object' ], from_) }
+export function Gio_IOStream(from_: GObject.Object) { return c<Gio.IOStream>('Gio.IOStream', [ 'GObject.Object' ], from_) }
+export function Gio_InetAddress(from_: GObject.Object) { return c<Gio.InetAddress>('Gio.InetAddress', [ 'GObject.Object' ], from_) }
+export function Gio_InetAddressMask(from_: GObject.Object) { return c<Gio.InetAddressMask>('Gio.InetAddressMask', [ 'GObject.Object', 'Gio.Initable' ], from_) }
+export function Gio_InetSocketAddress(from_: GObject.Object) { return c<Gio.InetSocketAddress>('Gio.InetSocketAddress', [ 'Gio.SocketAddress', 'Gio.SocketConnectable', 'GObject.Object' ], from_) }
+export function Gio_InputStream(from_: GObject.Object) { return c<Gio.InputStream>('Gio.InputStream', [ 'GObject.Object' ], from_) }
+export function Gio_ListStore(from_: GObject.Object) { return c<Gio.ListStore>('Gio.ListStore', [ 'GObject.Object', 'Gio.ListModel' ], from_) }
+export function Gio_MemoryInputStream(from_: GObject.Object) { return c<Gio.MemoryInputStream>('Gio.MemoryInputStream', [ 'Gio.InputStream', 'Gio.PollableInputStream', 'Gio.Seekable', 'GObject.Object' ], from_) }
+export function Gio_MemoryOutputStream(from_: GObject.Object) { return c<Gio.MemoryOutputStream>('Gio.MemoryOutputStream', [ 'Gio.OutputStream', 'Gio.PollableOutputStream', 'Gio.Seekable', 'GObject.Object' ], from_) }
+export function Gio_Menu(from_: GObject.Object) { return c<Gio.Menu>('Gio.Menu', [ 'Gio.MenuModel', 'GObject.Object' ], from_) }
+export function Gio_MenuAttributeIter(from_: GObject.Object) { return c<Gio.MenuAttributeIter>('Gio.MenuAttributeIter', [ 'GObject.Object' ], from_) }
+export function Gio_MenuItem(from_: GObject.Object) { return c<Gio.MenuItem>('Gio.MenuItem', [ 'GObject.Object' ], from_) }
+export function Gio_MenuLinkIter(from_: GObject.Object) { return c<Gio.MenuLinkIter>('Gio.MenuLinkIter', [ 'GObject.Object' ], from_) }
+export function Gio_MenuModel(from_: GObject.Object) { return c<Gio.MenuModel>('Gio.MenuModel', [ 'GObject.Object' ], from_) }
+export function Gio_MountOperation(from_: GObject.Object) { return c<Gio.MountOperation>('Gio.MountOperation', [ 'GObject.Object' ], from_) }
+export function Gio_NativeVolumeMonitor(from_: GObject.Object) { return c<Gio.NativeVolumeMonitor>('Gio.NativeVolumeMonitor', [ 'Gio.VolumeMonitor', 'GObject.Object' ], from_) }
+export function Gio_NetworkAddress(from_: GObject.Object) { return c<Gio.NetworkAddress>('Gio.NetworkAddress', [ 'GObject.Object', 'Gio.SocketConnectable' ], from_) }
+export function Gio_NetworkService(from_: GObject.Object) { return c<Gio.NetworkService>('Gio.NetworkService', [ 'GObject.Object', 'Gio.SocketConnectable' ], from_) }
+export function Gio_Notification(from_: GObject.Object) { return c<Gio.Notification>('Gio.Notification', [ 'GObject.Object' ], from_) }
+export function Gio_OutputStream(from_: GObject.Object) { return c<Gio.OutputStream>('Gio.OutputStream', [ 'GObject.Object' ], from_) }
+export function Gio_Permission(from_: GObject.Object) { return c<Gio.Permission>('Gio.Permission', [ 'GObject.Object' ], from_) }
+export function Gio_PropertyAction(from_: GObject.Object) { return c<Gio.PropertyAction>('Gio.PropertyAction', [ 'GObject.Object', 'Gio.Action' ], from_) }
+export function Gio_ProxyAddress(from_: GObject.Object) { return c<Gio.ProxyAddress>('Gio.ProxyAddress', [ 'Gio.InetSocketAddress', 'Gio.SocketConnectable', 'Gio.SocketAddress', 'GObject.Object' ], from_) }
+export function Gio_ProxyAddressEnumerator(from_: GObject.Object) { return c<Gio.ProxyAddressEnumerator>('Gio.ProxyAddressEnumerator', [ 'Gio.SocketAddressEnumerator', 'GObject.Object' ], from_) }
+export function Gio_Resolver(from_: GObject.Object) { return c<Gio.Resolver>('Gio.Resolver', [ 'GObject.Object' ], from_) }
+export function Gio_Settings(from_: GObject.Object) { return c<Gio.Settings>('Gio.Settings', [ 'GObject.Object' ], from_) }
+export function Gio_SettingsBackend(from_: GObject.Object) { return c<Gio.SettingsBackend>('Gio.SettingsBackend', [ 'GObject.Object' ], from_) }
+export function Gio_SimpleAction(from_: GObject.Object) { return c<Gio.SimpleAction>('Gio.SimpleAction', [ 'GObject.Object', 'Gio.Action' ], from_) }
+export function Gio_SimpleActionGroup(from_: GObject.Object) { return c<Gio.SimpleActionGroup>('Gio.SimpleActionGroup', [ 'GObject.Object', 'Gio.ActionGroup', 'Gio.ActionMap' ], from_) }
+export function Gio_SimpleAsyncResult(from_: GObject.Object) { return c<Gio.SimpleAsyncResult>('Gio.SimpleAsyncResult', [ 'GObject.Object', 'Gio.AsyncResult' ], from_) }
+export function Gio_SimpleIOStream(from_: GObject.Object) { return c<Gio.SimpleIOStream>('Gio.SimpleIOStream', [ 'Gio.IOStream', 'GObject.Object' ], from_) }
+export function Gio_SimplePermission(from_: GObject.Object) { return c<Gio.SimplePermission>('Gio.SimplePermission', [ 'Gio.Permission', 'GObject.Object' ], from_) }
+export function Gio_SimpleProxyResolver(from_: GObject.Object) { return c<Gio.SimpleProxyResolver>('Gio.SimpleProxyResolver', [ 'GObject.Object', 'Gio.ProxyResolver' ], from_) }
+export function Gio_Socket(from_: GObject.Object) { return c<Gio.Socket>('Gio.Socket', [ 'GObject.Object', 'Gio.DatagramBased', 'Gio.Initable' ], from_) }
+export function Gio_SocketAddress(from_: GObject.Object) { return c<Gio.SocketAddress>('Gio.SocketAddress', [ 'GObject.Object', 'Gio.SocketConnectable' ], from_) }
+export function Gio_SocketAddressEnumerator(from_: GObject.Object) { return c<Gio.SocketAddressEnumerator>('Gio.SocketAddressEnumerator', [ 'GObject.Object' ], from_) }
+export function Gio_SocketClient(from_: GObject.Object) { return c<Gio.SocketClient>('Gio.SocketClient', [ 'GObject.Object' ], from_) }
+export function Gio_SocketConnection(from_: GObject.Object) { return c<Gio.SocketConnection>('Gio.SocketConnection', [ 'Gio.IOStream', 'GObject.Object' ], from_) }
+export function Gio_SocketControlMessage(from_: GObject.Object) { return c<Gio.SocketControlMessage>('Gio.SocketControlMessage', [ 'GObject.Object' ], from_) }
+export function Gio_SocketListener(from_: GObject.Object) { return c<Gio.SocketListener>('Gio.SocketListener', [ 'GObject.Object' ], from_) }
+export function Gio_SocketService(from_: GObject.Object) { return c<Gio.SocketService>('Gio.SocketService', [ 'Gio.SocketListener', 'GObject.Object' ], from_) }
+export function Gio_Subprocess(from_: GObject.Object) { return c<Gio.Subprocess>('Gio.Subprocess', [ 'GObject.Object', 'Gio.Initable' ], from_) }
+export function Gio_SubprocessLauncher(from_: GObject.Object) { return c<Gio.SubprocessLauncher>('Gio.SubprocessLauncher', [ 'GObject.Object' ], from_) }
+export function Gio_Task(from_: GObject.Object) { return c<Gio.Task>('Gio.Task', [ 'GObject.Object', 'Gio.AsyncResult' ], from_) }
+export function Gio_TcpConnection(from_: GObject.Object) { return c<Gio.TcpConnection>('Gio.TcpConnection', [ 'Gio.SocketConnection', 'Gio.IOStream', 'GObject.Object' ], from_) }
+export function Gio_TcpWrapperConnection(from_: GObject.Object) { return c<Gio.TcpWrapperConnection>('Gio.TcpWrapperConnection', [ 'Gio.TcpConnection', 'Gio.SocketConnection', 'Gio.IOStream', 'GObject.Object' ], from_) }
+export function Gio_TestDBus(from_: GObject.Object) { return c<Gio.TestDBus>('Gio.TestDBus', [ 'GObject.Object' ], from_) }
+export function Gio_ThemedIcon(from_: GObject.Object) { return c<Gio.ThemedIcon>('Gio.ThemedIcon', [ 'GObject.Object', 'Gio.Icon' ], from_) }
+export function Gio_ThreadedSocketService(from_: GObject.Object) { return c<Gio.ThreadedSocketService>('Gio.ThreadedSocketService', [ 'Gio.SocketService', 'Gio.SocketListener', 'GObject.Object' ], from_) }
+export function Gio_TlsCertificate(from_: GObject.Object) { return c<Gio.TlsCertificate>('Gio.TlsCertificate', [ 'GObject.Object' ], from_) }
+export function Gio_TlsConnection(from_: GObject.Object) { return c<Gio.TlsConnection>('Gio.TlsConnection', [ 'Gio.IOStream', 'GObject.Object' ], from_) }
+export function Gio_TlsDatabase(from_: GObject.Object) { return c<Gio.TlsDatabase>('Gio.TlsDatabase', [ 'GObject.Object' ], from_) }
+export function Gio_TlsInteraction(from_: GObject.Object) { return c<Gio.TlsInteraction>('Gio.TlsInteraction', [ 'GObject.Object' ], from_) }
+export function Gio_TlsPassword(from_: GObject.Object) { return c<Gio.TlsPassword>('Gio.TlsPassword', [ 'GObject.Object' ], from_) }
+export function Gio_UnixConnection(from_: GObject.Object) { return c<Gio.UnixConnection>('Gio.UnixConnection', [ 'Gio.SocketConnection', 'Gio.IOStream', 'GObject.Object' ], from_) }
+export function Gio_UnixCredentialsMessage(from_: GObject.Object) { return c<Gio.UnixCredentialsMessage>('Gio.UnixCredentialsMessage', [ 'Gio.SocketControlMessage', 'GObject.Object' ], from_) }
+export function Gio_UnixFDList(from_: GObject.Object) { return c<Gio.UnixFDList>('Gio.UnixFDList', [ 'GObject.Object' ], from_) }
+export function Gio_UnixFDMessage(from_: GObject.Object) { return c<Gio.UnixFDMessage>('Gio.UnixFDMessage', [ 'Gio.SocketControlMessage', 'GObject.Object' ], from_) }
+export function Gio_UnixInputStream(from_: GObject.Object) { return c<Gio.UnixInputStream>('Gio.UnixInputStream', [ 'Gio.InputStream', 'Gio.FileDescriptorBased', 'Gio.PollableInputStream', 'GObject.Object' ], from_) }
+export function Gio_UnixMountMonitor(from_: GObject.Object) { return c<Gio.UnixMountMonitor>('Gio.UnixMountMonitor', [ 'GObject.Object' ], from_) }
+export function Gio_UnixOutputStream(from_: GObject.Object) { return c<Gio.UnixOutputStream>('Gio.UnixOutputStream', [ 'Gio.OutputStream', 'Gio.FileDescriptorBased', 'Gio.PollableOutputStream', 'GObject.Object' ], from_) }
+export function Gio_UnixSocketAddress(from_: GObject.Object) { return c<Gio.UnixSocketAddress>('Gio.UnixSocketAddress', [ 'Gio.SocketAddress', 'Gio.SocketConnectable', 'GObject.Object' ], from_) }
+export function Gio_Vfs(from_: GObject.Object) { return c<Gio.Vfs>('Gio.Vfs', [ 'GObject.Object' ], from_) }
+export function Gio_VolumeMonitor(from_: GObject.Object) { return c<Gio.VolumeMonitor>('Gio.VolumeMonitor', [ 'GObject.Object' ], from_) }
+export function Gio_ZlibCompressor(from_: GObject.Object) { return c<Gio.ZlibCompressor>('Gio.ZlibCompressor', [ 'GObject.Object', 'Gio.Converter' ], from_) }
+export function Gio_ZlibDecompressor(from_: GObject.Object) { return c<Gio.ZlibDecompressor>('Gio.ZlibDecompressor', [ 'GObject.Object', 'Gio.Converter' ], from_) }
+export function Pango_Context(from_: GObject.Object) { return c<Pango.Context>('Pango.Context', [ 'GObject.Object' ], from_) }
+export function Pango_Engine(from_: GObject.Object) { return c<Pango.Engine>('Pango.Engine', [ 'GObject.Object' ], from_) }
+export function Pango_EngineLang(from_: GObject.Object) { return c<Pango.EngineLang>('Pango.EngineLang', [ 'Pango.Engine', 'GObject.Object' ], from_) }
+export function Pango_EngineShape(from_: GObject.Object) { return c<Pango.EngineShape>('Pango.EngineShape', [ 'Pango.Engine', 'GObject.Object' ], from_) }
+export function Pango_Font(from_: GObject.Object) { return c<Pango.Font>('Pango.Font', [ 'GObject.Object' ], from_) }
+export function Pango_FontFace(from_: GObject.Object) { return c<Pango.FontFace>('Pango.FontFace', [ 'GObject.Object' ], from_) }
+export function Pango_FontFamily(from_: GObject.Object) { return c<Pango.FontFamily>('Pango.FontFamily', [ 'GObject.Object' ], from_) }
+export function Pango_FontMap(from_: GObject.Object) { return c<Pango.FontMap>('Pango.FontMap', [ 'GObject.Object' ], from_) }
+export function Pango_Fontset(from_: GObject.Object) { return c<Pango.Fontset>('Pango.Fontset', [ 'GObject.Object' ], from_) }
+export function Pango_FontsetSimple(from_: GObject.Object) { return c<Pango.FontsetSimple>('Pango.FontsetSimple', [ 'Pango.Fontset', 'GObject.Object' ], from_) }
+export function Pango_Layout(from_: GObject.Object) { return c<Pango.Layout>('Pango.Layout', [ 'GObject.Object' ], from_) }
+export function Pango_Renderer(from_: GObject.Object) { return c<Pango.Renderer>('Pango.Renderer', [ 'GObject.Object' ], from_) }
+export function Soup_Address(from_: GObject.Object) { return c<Soup.Address>('Soup.Address', [ 'GObject.Object', 'Gio.SocketConnectable' ], from_) }
+export function Soup_Auth(from_: GObject.Object) { return c<Soup.Auth>('Soup.Auth', [ 'GObject.Object' ], from_) }
+export function Soup_AuthBasic(from_: GObject.Object) { return c<Soup.AuthBasic>('Soup.AuthBasic', [ 'Soup.Auth', 'GObject.Object' ], from_) }
+export function Soup_AuthDigest(from_: GObject.Object) { return c<Soup.AuthDigest>('Soup.AuthDigest', [ 'Soup.Auth', 'GObject.Object' ], from_) }
+export function Soup_AuthDomain(from_: GObject.Object) { return c<Soup.AuthDomain>('Soup.AuthDomain', [ 'GObject.Object' ], from_) }
+export function Soup_AuthDomainBasic(from_: GObject.Object) { return c<Soup.AuthDomainBasic>('Soup.AuthDomainBasic', [ 'Soup.AuthDomain', 'GObject.Object' ], from_) }
+export function Soup_AuthDomainDigest(from_: GObject.Object) { return c<Soup.AuthDomainDigest>('Soup.AuthDomainDigest', [ 'Soup.AuthDomain', 'GObject.Object' ], from_) }
+export function Soup_AuthManager(from_: GObject.Object) { return c<Soup.AuthManager>('Soup.AuthManager', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_AuthNTLM(from_: GObject.Object) { return c<Soup.AuthNTLM>('Soup.AuthNTLM', [ 'Soup.Auth', 'GObject.Object' ], from_) }
+export function Soup_AuthNegotiate(from_: GObject.Object) { return c<Soup.AuthNegotiate>('Soup.AuthNegotiate', [ 'Soup.Auth', 'GObject.Object' ], from_) }
+export function Soup_Cache(from_: GObject.Object) { return c<Soup.Cache>('Soup.Cache', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_ContentDecoder(from_: GObject.Object) { return c<Soup.ContentDecoder>('Soup.ContentDecoder', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_ContentSniffer(from_: GObject.Object) { return c<Soup.ContentSniffer>('Soup.ContentSniffer', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_CookieJar(from_: GObject.Object) { return c<Soup.CookieJar>('Soup.CookieJar', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_CookieJarDB(from_: GObject.Object) { return c<Soup.CookieJarDB>('Soup.CookieJarDB', [ 'Soup.CookieJar', 'Soup.SessionFeature', 'GObject.Object' ], from_) }
+export function Soup_CookieJarText(from_: GObject.Object) { return c<Soup.CookieJarText>('Soup.CookieJarText', [ 'Soup.CookieJar', 'Soup.SessionFeature', 'GObject.Object' ], from_) }
+export function Soup_Logger(from_: GObject.Object) { return c<Soup.Logger>('Soup.Logger', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_Message(from_: GObject.Object) { return c<Soup.Message>('Soup.Message', [ 'GObject.Object' ], from_) }
+export function Soup_MultipartInputStream(from_: GObject.Object) { return c<Soup.MultipartInputStream>('Soup.MultipartInputStream', [ 'Gio.FilterInputStream', 'Gio.PollableInputStream', 'Gio.InputStream', 'GObject.Object' ], from_) }
+export function Soup_ProxyResolverDefault(from_: GObject.Object) { return c<Soup.ProxyResolverDefault>('Soup.ProxyResolverDefault', [ 'GObject.Object', 'Soup.ProxyURIResolver', 'Soup.SessionFeature' ], from_) }
+export function Soup_Request(from_: GObject.Object) { return c<Soup.Request>('Soup.Request', [ 'GObject.Object', 'Gio.Initable' ], from_) }
+export function Soup_RequestData(from_: GObject.Object) { return c<Soup.RequestData>('Soup.RequestData', [ 'Soup.Request', 'Gio.Initable', 'GObject.Object' ], from_) }
+export function Soup_RequestFile(from_: GObject.Object) { return c<Soup.RequestFile>('Soup.RequestFile', [ 'Soup.Request', 'Gio.Initable', 'GObject.Object' ], from_) }
+export function Soup_RequestHTTP(from_: GObject.Object) { return c<Soup.RequestHTTP>('Soup.RequestHTTP', [ 'Soup.Request', 'Gio.Initable', 'GObject.Object' ], from_) }
+export function Soup_Requester(from_: GObject.Object) { return c<Soup.Requester>('Soup.Requester', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function Soup_Server(from_: GObject.Object) { return c<Soup.Server>('Soup.Server', [ 'GObject.Object' ], from_) }
+export function Soup_Session(from_: GObject.Object) { return c<Soup.Session>('Soup.Session', [ 'GObject.Object' ], from_) }
+export function Soup_SessionAsync(from_: GObject.Object) { return c<Soup.SessionAsync>('Soup.SessionAsync', [ 'Soup.Session', 'GObject.Object' ], from_) }
+export function Soup_SessionSync(from_: GObject.Object) { return c<Soup.SessionSync>('Soup.SessionSync', [ 'Soup.Session', 'GObject.Object' ], from_) }
+export function Soup_Socket(from_: GObject.Object) { return c<Soup.Socket>('Soup.Socket', [ 'GObject.Object', 'Gio.Initable' ], from_) }
+export function Soup_WebsocketConnection(from_: GObject.Object) { return c<Soup.WebsocketConnection>('Soup.WebsocketConnection', [ 'GObject.Object' ], from_) }
+export function GtkSource_Buffer(from_: GObject.Object) { return c<GtkSource.Buffer>('GtkSource.Buffer', [ 'Gtk.TextBuffer', 'GObject.Object' ], from_) }
+export function GtkSource_Completion(from_: GObject.Object) { return c<GtkSource.Completion>('GtkSource.Completion', [ 'GObject.Object', 'Gtk.Buildable' ], from_) }
+export function GtkSource_CompletionContext(from_: GObject.Object) { return c<GtkSource.CompletionContext>('GtkSource.CompletionContext', [ 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_CompletionInfo(from_: GObject.Object) { return c<GtkSource.CompletionInfo>('GtkSource.CompletionInfo', [ 'Gtk.Window', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_CompletionItem(from_: GObject.Object) { return c<GtkSource.CompletionItem>('GtkSource.CompletionItem', [ 'GObject.Object', 'GtkSource.CompletionProposal' ], from_) }
+export function GtkSource_CompletionWords(from_: GObject.Object) { return c<GtkSource.CompletionWords>('GtkSource.CompletionWords', [ 'GObject.Object', 'GtkSource.CompletionProvider' ], from_) }
+export function GtkSource_File(from_: GObject.Object) { return c<GtkSource.File>('GtkSource.File', [ 'GObject.Object' ], from_) }
+export function GtkSource_FileLoader(from_: GObject.Object) { return c<GtkSource.FileLoader>('GtkSource.FileLoader', [ 'GObject.Object' ], from_) }
+export function GtkSource_FileSaver(from_: GObject.Object) { return c<GtkSource.FileSaver>('GtkSource.FileSaver', [ 'GObject.Object' ], from_) }
+export function GtkSource_Gutter(from_: GObject.Object) { return c<GtkSource.Gutter>('GtkSource.Gutter', [ 'GObject.Object' ], from_) }
+export function GtkSource_GutterRenderer(from_: GObject.Object) { return c<GtkSource.GutterRenderer>('GtkSource.GutterRenderer', [ 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_GutterRendererPixbuf(from_: GObject.Object) { return c<GtkSource.GutterRendererPixbuf>('GtkSource.GutterRendererPixbuf', [ 'GtkSource.GutterRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_GutterRendererText(from_: GObject.Object) { return c<GtkSource.GutterRendererText>('GtkSource.GutterRendererText', [ 'GtkSource.GutterRenderer', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_Language(from_: GObject.Object) { return c<GtkSource.Language>('GtkSource.Language', [ 'GObject.Object' ], from_) }
+export function GtkSource_LanguageManager(from_: GObject.Object) { return c<GtkSource.LanguageManager>('GtkSource.LanguageManager', [ 'GObject.Object' ], from_) }
+export function GtkSource_Map(from_: GObject.Object) { return c<GtkSource.Map>('GtkSource.Map', [ 'GtkSource.View', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.TextView', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_Mark(from_: GObject.Object) { return c<GtkSource.Mark>('GtkSource.Mark', [ 'Gtk.TextMark', 'GObject.Object' ], from_) }
+export function GtkSource_MarkAttributes(from_: GObject.Object) { return c<GtkSource.MarkAttributes>('GtkSource.MarkAttributes', [ 'GObject.Object' ], from_) }
+export function GtkSource_PrintCompositor(from_: GObject.Object) { return c<GtkSource.PrintCompositor>('GtkSource.PrintCompositor', [ 'GObject.Object' ], from_) }
+export function GtkSource_Region(from_: GObject.Object) { return c<GtkSource.Region>('GtkSource.Region', [ 'GObject.Object' ], from_) }
+export function GtkSource_SearchContext(from_: GObject.Object) { return c<GtkSource.SearchContext>('GtkSource.SearchContext', [ 'GObject.Object' ], from_) }
+export function GtkSource_SearchSettings(from_: GObject.Object) { return c<GtkSource.SearchSettings>('GtkSource.SearchSettings', [ 'GObject.Object' ], from_) }
+export function GtkSource_SpaceDrawer(from_: GObject.Object) { return c<GtkSource.SpaceDrawer>('GtkSource.SpaceDrawer', [ 'GObject.Object' ], from_) }
+export function GtkSource_Style(from_: GObject.Object) { return c<GtkSource.Style>('GtkSource.Style', [ 'GObject.Object' ], from_) }
+export function GtkSource_StyleScheme(from_: GObject.Object) { return c<GtkSource.StyleScheme>('GtkSource.StyleScheme', [ 'GObject.Object' ], from_) }
+export function GtkSource_StyleSchemeChooserButton(from_: GObject.Object) { return c<GtkSource.StyleSchemeChooserButton>('GtkSource.StyleSchemeChooserButton', [ 'Gtk.Button', 'Atk.ImplementorIface', 'Gtk.Actionable', 'Gtk.Activatable', 'Gtk.Buildable', 'GtkSource.StyleSchemeChooser', 'Gtk.Bin', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_StyleSchemeChooserWidget(from_: GObject.Object) { return c<GtkSource.StyleSchemeChooserWidget>('GtkSource.StyleSchemeChooserWidget', [ 'Gtk.Bin', 'Atk.ImplementorIface', 'Gtk.Buildable', 'GtkSource.StyleSchemeChooser', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function GtkSource_StyleSchemeManager(from_: GObject.Object) { return c<GtkSource.StyleSchemeManager>('GtkSource.StyleSchemeManager', [ 'GObject.Object' ], from_) }
+export function GtkSource_Tag(from_: GObject.Object) { return c<GtkSource.Tag>('GtkSource.Tag', [ 'Gtk.TextTag', 'GObject.Object' ], from_) }
+export function GtkSource_View(from_: GObject.Object) { return c<GtkSource.View>('GtkSource.View', [ 'Gtk.TextView', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Container', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function WebKit_DOMAttr(from_: GObject.Object) { return c<WebKit.DOMAttr>('WebKit.DOMAttr', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMAudioTrack(from_: GObject.Object) { return c<WebKit.DOMAudioTrack>('WebKit.DOMAudioTrack', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMAudioTrackList(from_: GObject.Object) { return c<WebKit.DOMAudioTrackList>('WebKit.DOMAudioTrackList', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMBarInfo(from_: GObject.Object) { return c<WebKit.DOMBarInfo>('WebKit.DOMBarInfo', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMBarProp(from_: GObject.Object) { return c<WebKit.DOMBarProp>('WebKit.DOMBarProp', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMBatteryManager(from_: GObject.Object) { return c<WebKit.DOMBatteryManager>('WebKit.DOMBatteryManager', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMBlob(from_: GObject.Object) { return c<WebKit.DOMBlob>('WebKit.DOMBlob', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCDATASection(from_: GObject.Object) { return c<WebKit.DOMCDATASection>('WebKit.DOMCDATASection', [ 'WebKit.DOMText', 'WebKit.DOMEventTarget', 'WebKit.DOMCharacterData', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCSSRule(from_: GObject.Object) { return c<WebKit.DOMCSSRule>('WebKit.DOMCSSRule', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCSSRuleList(from_: GObject.Object) { return c<WebKit.DOMCSSRuleList>('WebKit.DOMCSSRuleList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCSSStyleDeclaration(from_: GObject.Object) { return c<WebKit.DOMCSSStyleDeclaration>('WebKit.DOMCSSStyleDeclaration', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCSSStyleSheet(from_: GObject.Object) { return c<WebKit.DOMCSSStyleSheet>('WebKit.DOMCSSStyleSheet', [ 'WebKit.DOMStyleSheet', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCSSValue(from_: GObject.Object) { return c<WebKit.DOMCSSValue>('WebKit.DOMCSSValue', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMCharacterData(from_: GObject.Object) { return c<WebKit.DOMCharacterData>('WebKit.DOMCharacterData', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMComment(from_: GObject.Object) { return c<WebKit.DOMComment>('WebKit.DOMComment', [ 'WebKit.DOMCharacterData', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMConsole(from_: GObject.Object) { return c<WebKit.DOMConsole>('WebKit.DOMConsole', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMApplicationCache(from_: GObject.Object) { return c<WebKit.DOMDOMApplicationCache>('WebKit.DOMDOMApplicationCache', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMImplementation(from_: GObject.Object) { return c<WebKit.DOMDOMImplementation>('WebKit.DOMDOMImplementation', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMMimeType(from_: GObject.Object) { return c<WebKit.DOMDOMMimeType>('WebKit.DOMDOMMimeType', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMMimeTypeArray(from_: GObject.Object) { return c<WebKit.DOMDOMMimeTypeArray>('WebKit.DOMDOMMimeTypeArray', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMNamedFlowCollection(from_: GObject.Object) { return c<WebKit.DOMDOMNamedFlowCollection>('WebKit.DOMDOMNamedFlowCollection', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMPlugin(from_: GObject.Object) { return c<WebKit.DOMDOMPlugin>('WebKit.DOMDOMPlugin', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMPluginArray(from_: GObject.Object) { return c<WebKit.DOMDOMPluginArray>('WebKit.DOMDOMPluginArray', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMSecurityPolicy(from_: GObject.Object) { return c<WebKit.DOMDOMSecurityPolicy>('WebKit.DOMDOMSecurityPolicy', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMSelection(from_: GObject.Object) { return c<WebKit.DOMDOMSelection>('WebKit.DOMDOMSelection', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMSettableTokenList(from_: GObject.Object) { return c<WebKit.DOMDOMSettableTokenList>('WebKit.DOMDOMSettableTokenList', [ 'WebKit.DOMDOMTokenList', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMStringList(from_: GObject.Object) { return c<WebKit.DOMDOMStringList>('WebKit.DOMDOMStringList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMStringMap(from_: GObject.Object) { return c<WebKit.DOMDOMStringMap>('WebKit.DOMDOMStringMap', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMTokenList(from_: GObject.Object) { return c<WebKit.DOMDOMTokenList>('WebKit.DOMDOMTokenList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMWindow(from_: GObject.Object) { return c<WebKit.DOMDOMWindow>('WebKit.DOMDOMWindow', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMDOMWindowCSS(from_: GObject.Object) { return c<WebKit.DOMDOMWindowCSS>('WebKit.DOMDOMWindowCSS', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDatabase(from_: GObject.Object) { return c<WebKit.DOMDatabase>('WebKit.DOMDatabase', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDocument(from_: GObject.Object) { return c<WebKit.DOMDocument>('WebKit.DOMDocument', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDocumentFragment(from_: GObject.Object) { return c<WebKit.DOMDocumentFragment>('WebKit.DOMDocumentFragment', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMDocumentType(from_: GObject.Object) { return c<WebKit.DOMDocumentType>('WebKit.DOMDocumentType', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMElement(from_: GObject.Object) { return c<WebKit.DOMElement>('WebKit.DOMElement', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMEntityReference(from_: GObject.Object) { return c<WebKit.DOMEntityReference>('WebKit.DOMEntityReference', [ 'WebKit.DOMNode', 'WebKit.DOMEventTarget', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMEvent(from_: GObject.Object) { return c<WebKit.DOMEvent>('WebKit.DOMEvent', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMFile(from_: GObject.Object) { return c<WebKit.DOMFile>('WebKit.DOMFile', [ 'WebKit.DOMBlob', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMFileList(from_: GObject.Object) { return c<WebKit.DOMFileList>('WebKit.DOMFileList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMGamepad(from_: GObject.Object) { return c<WebKit.DOMGamepad>('WebKit.DOMGamepad', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMGamepadList(from_: GObject.Object) { return c<WebKit.DOMGamepadList>('WebKit.DOMGamepadList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMGeolocation(from_: GObject.Object) { return c<WebKit.DOMGeolocation>('WebKit.DOMGeolocation', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLAnchorElement(from_: GObject.Object) { return c<WebKit.DOMHTMLAnchorElement>('WebKit.DOMHTMLAnchorElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLAppletElement(from_: GObject.Object) { return c<WebKit.DOMHTMLAppletElement>('WebKit.DOMHTMLAppletElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLAreaElement(from_: GObject.Object) { return c<WebKit.DOMHTMLAreaElement>('WebKit.DOMHTMLAreaElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLAudioElement(from_: GObject.Object) { return c<WebKit.DOMHTMLAudioElement>('WebKit.DOMHTMLAudioElement', [ 'WebKit.DOMHTMLMediaElement', 'WebKit.DOMEventTarget', 'WebKit.DOMHTMLElement', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLBRElement(from_: GObject.Object) { return c<WebKit.DOMHTMLBRElement>('WebKit.DOMHTMLBRElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLBaseElement(from_: GObject.Object) { return c<WebKit.DOMHTMLBaseElement>('WebKit.DOMHTMLBaseElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLBaseFontElement(from_: GObject.Object) { return c<WebKit.DOMHTMLBaseFontElement>('WebKit.DOMHTMLBaseFontElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLBodyElement(from_: GObject.Object) { return c<WebKit.DOMHTMLBodyElement>('WebKit.DOMHTMLBodyElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLButtonElement(from_: GObject.Object) { return c<WebKit.DOMHTMLButtonElement>('WebKit.DOMHTMLButtonElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLCanvasElement(from_: GObject.Object) { return c<WebKit.DOMHTMLCanvasElement>('WebKit.DOMHTMLCanvasElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLCollection(from_: GObject.Object) { return c<WebKit.DOMHTMLCollection>('WebKit.DOMHTMLCollection', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLDListElement(from_: GObject.Object) { return c<WebKit.DOMHTMLDListElement>('WebKit.DOMHTMLDListElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLDetailsElement(from_: GObject.Object) { return c<WebKit.DOMHTMLDetailsElement>('WebKit.DOMHTMLDetailsElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLDirectoryElement(from_: GObject.Object) { return c<WebKit.DOMHTMLDirectoryElement>('WebKit.DOMHTMLDirectoryElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLDivElement(from_: GObject.Object) { return c<WebKit.DOMHTMLDivElement>('WebKit.DOMHTMLDivElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLDocument(from_: GObject.Object) { return c<WebKit.DOMHTMLDocument>('WebKit.DOMHTMLDocument', [ 'WebKit.DOMDocument', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLElement(from_: GObject.Object) { return c<WebKit.DOMHTMLElement>('WebKit.DOMHTMLElement', [ 'WebKit.DOMElement', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLEmbedElement(from_: GObject.Object) { return c<WebKit.DOMHTMLEmbedElement>('WebKit.DOMHTMLEmbedElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLFieldSetElement(from_: GObject.Object) { return c<WebKit.DOMHTMLFieldSetElement>('WebKit.DOMHTMLFieldSetElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLFontElement(from_: GObject.Object) { return c<WebKit.DOMHTMLFontElement>('WebKit.DOMHTMLFontElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLFormElement(from_: GObject.Object) { return c<WebKit.DOMHTMLFormElement>('WebKit.DOMHTMLFormElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLFrameElement(from_: GObject.Object) { return c<WebKit.DOMHTMLFrameElement>('WebKit.DOMHTMLFrameElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLFrameSetElement(from_: GObject.Object) { return c<WebKit.DOMHTMLFrameSetElement>('WebKit.DOMHTMLFrameSetElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLHRElement(from_: GObject.Object) { return c<WebKit.DOMHTMLHRElement>('WebKit.DOMHTMLHRElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLHeadElement(from_: GObject.Object) { return c<WebKit.DOMHTMLHeadElement>('WebKit.DOMHTMLHeadElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLHeadingElement(from_: GObject.Object) { return c<WebKit.DOMHTMLHeadingElement>('WebKit.DOMHTMLHeadingElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLHtmlElement(from_: GObject.Object) { return c<WebKit.DOMHTMLHtmlElement>('WebKit.DOMHTMLHtmlElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLIFrameElement(from_: GObject.Object) { return c<WebKit.DOMHTMLIFrameElement>('WebKit.DOMHTMLIFrameElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLImageElement(from_: GObject.Object) { return c<WebKit.DOMHTMLImageElement>('WebKit.DOMHTMLImageElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLInputElement(from_: GObject.Object) { return c<WebKit.DOMHTMLInputElement>('WebKit.DOMHTMLInputElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLKeygenElement(from_: GObject.Object) { return c<WebKit.DOMHTMLKeygenElement>('WebKit.DOMHTMLKeygenElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLLIElement(from_: GObject.Object) { return c<WebKit.DOMHTMLLIElement>('WebKit.DOMHTMLLIElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLLabelElement(from_: GObject.Object) { return c<WebKit.DOMHTMLLabelElement>('WebKit.DOMHTMLLabelElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLLegendElement(from_: GObject.Object) { return c<WebKit.DOMHTMLLegendElement>('WebKit.DOMHTMLLegendElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLLinkElement(from_: GObject.Object) { return c<WebKit.DOMHTMLLinkElement>('WebKit.DOMHTMLLinkElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLMapElement(from_: GObject.Object) { return c<WebKit.DOMHTMLMapElement>('WebKit.DOMHTMLMapElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLMarqueeElement(from_: GObject.Object) { return c<WebKit.DOMHTMLMarqueeElement>('WebKit.DOMHTMLMarqueeElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLMediaElement(from_: GObject.Object) { return c<WebKit.DOMHTMLMediaElement>('WebKit.DOMHTMLMediaElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLMenuElement(from_: GObject.Object) { return c<WebKit.DOMHTMLMenuElement>('WebKit.DOMHTMLMenuElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLMetaElement(from_: GObject.Object) { return c<WebKit.DOMHTMLMetaElement>('WebKit.DOMHTMLMetaElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLModElement(from_: GObject.Object) { return c<WebKit.DOMHTMLModElement>('WebKit.DOMHTMLModElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLOListElement(from_: GObject.Object) { return c<WebKit.DOMHTMLOListElement>('WebKit.DOMHTMLOListElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLObjectElement(from_: GObject.Object) { return c<WebKit.DOMHTMLObjectElement>('WebKit.DOMHTMLObjectElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLOptGroupElement(from_: GObject.Object) { return c<WebKit.DOMHTMLOptGroupElement>('WebKit.DOMHTMLOptGroupElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLOptionElement(from_: GObject.Object) { return c<WebKit.DOMHTMLOptionElement>('WebKit.DOMHTMLOptionElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLOptionsCollection(from_: GObject.Object) { return c<WebKit.DOMHTMLOptionsCollection>('WebKit.DOMHTMLOptionsCollection', [ 'WebKit.DOMHTMLCollection', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLParagraphElement(from_: GObject.Object) { return c<WebKit.DOMHTMLParagraphElement>('WebKit.DOMHTMLParagraphElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLParamElement(from_: GObject.Object) { return c<WebKit.DOMHTMLParamElement>('WebKit.DOMHTMLParamElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLPreElement(from_: GObject.Object) { return c<WebKit.DOMHTMLPreElement>('WebKit.DOMHTMLPreElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLPropertiesCollection(from_: GObject.Object) { return c<WebKit.DOMHTMLPropertiesCollection>('WebKit.DOMHTMLPropertiesCollection', [ 'WebKit.DOMHTMLCollection', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLQuoteElement(from_: GObject.Object) { return c<WebKit.DOMHTMLQuoteElement>('WebKit.DOMHTMLQuoteElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLScriptElement(from_: GObject.Object) { return c<WebKit.DOMHTMLScriptElement>('WebKit.DOMHTMLScriptElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLSelectElement(from_: GObject.Object) { return c<WebKit.DOMHTMLSelectElement>('WebKit.DOMHTMLSelectElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLStyleElement(from_: GObject.Object) { return c<WebKit.DOMHTMLStyleElement>('WebKit.DOMHTMLStyleElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTableCaptionElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTableCaptionElement>('WebKit.DOMHTMLTableCaptionElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTableCellElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTableCellElement>('WebKit.DOMHTMLTableCellElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTableColElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTableColElement>('WebKit.DOMHTMLTableColElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTableElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTableElement>('WebKit.DOMHTMLTableElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTableRowElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTableRowElement>('WebKit.DOMHTMLTableRowElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTableSectionElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTableSectionElement>('WebKit.DOMHTMLTableSectionElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTextAreaElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTextAreaElement>('WebKit.DOMHTMLTextAreaElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLTitleElement(from_: GObject.Object) { return c<WebKit.DOMHTMLTitleElement>('WebKit.DOMHTMLTitleElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLUListElement(from_: GObject.Object) { return c<WebKit.DOMHTMLUListElement>('WebKit.DOMHTMLUListElement', [ 'WebKit.DOMHTMLElement', 'WebKit.DOMEventTarget', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHTMLVideoElement(from_: GObject.Object) { return c<WebKit.DOMHTMLVideoElement>('WebKit.DOMHTMLVideoElement', [ 'WebKit.DOMHTMLMediaElement', 'WebKit.DOMEventTarget', 'WebKit.DOMHTMLElement', 'WebKit.DOMElement', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMHistory(from_: GObject.Object) { return c<WebKit.DOMHistory>('WebKit.DOMHistory', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMKeyboardEvent(from_: GObject.Object) { return c<WebKit.DOMKeyboardEvent>('WebKit.DOMKeyboardEvent', [ 'WebKit.DOMUIEvent', 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMLocation(from_: GObject.Object) { return c<WebKit.DOMLocation>('WebKit.DOMLocation', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMMediaController(from_: GObject.Object) { return c<WebKit.DOMMediaController>('WebKit.DOMMediaController', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMMediaError(from_: GObject.Object) { return c<WebKit.DOMMediaError>('WebKit.DOMMediaError', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMMediaList(from_: GObject.Object) { return c<WebKit.DOMMediaList>('WebKit.DOMMediaList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMMediaQueryList(from_: GObject.Object) { return c<WebKit.DOMMediaQueryList>('WebKit.DOMMediaQueryList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMMemoryInfo(from_: GObject.Object) { return c<WebKit.DOMMemoryInfo>('WebKit.DOMMemoryInfo', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMMessagePort(from_: GObject.Object) { return c<WebKit.DOMMessagePort>('WebKit.DOMMessagePort', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMMicroDataItemValue(from_: GObject.Object) { return c<WebKit.DOMMicroDataItemValue>('WebKit.DOMMicroDataItemValue', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMMouseEvent(from_: GObject.Object) { return c<WebKit.DOMMouseEvent>('WebKit.DOMMouseEvent', [ 'WebKit.DOMUIEvent', 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMNamedNodeMap(from_: GObject.Object) { return c<WebKit.DOMNamedNodeMap>('WebKit.DOMNamedNodeMap', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMNavigator(from_: GObject.Object) { return c<WebKit.DOMNavigator>('WebKit.DOMNavigator', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMNode(from_: GObject.Object) { return c<WebKit.DOMNode>('WebKit.DOMNode', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMNodeFilter(from_: GObject.Object) { return c<WebKit.DOMNodeFilter>('WebKit.DOMNodeFilter', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMNodeIterator(from_: GObject.Object) { return c<WebKit.DOMNodeIterator>('WebKit.DOMNodeIterator', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMNodeList(from_: GObject.Object) { return c<WebKit.DOMNodeList>('WebKit.DOMNodeList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMObject(from_: GObject.Object) { return c<WebKit.DOMObject>('WebKit.DOMObject', [ 'GObject.Object' ], from_) }
+export function WebKit_DOMPerformance(from_: GObject.Object) { return c<WebKit.DOMPerformance>('WebKit.DOMPerformance', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMPerformanceEntry(from_: GObject.Object) { return c<WebKit.DOMPerformanceEntry>('WebKit.DOMPerformanceEntry', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMPerformanceEntryList(from_: GObject.Object) { return c<WebKit.DOMPerformanceEntryList>('WebKit.DOMPerformanceEntryList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMPerformanceNavigation(from_: GObject.Object) { return c<WebKit.DOMPerformanceNavigation>('WebKit.DOMPerformanceNavigation', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMPerformanceTiming(from_: GObject.Object) { return c<WebKit.DOMPerformanceTiming>('WebKit.DOMPerformanceTiming', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMProcessingInstruction(from_: GObject.Object) { return c<WebKit.DOMProcessingInstruction>('WebKit.DOMProcessingInstruction', [ 'WebKit.DOMCharacterData', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMPropertyNodeList(from_: GObject.Object) { return c<WebKit.DOMPropertyNodeList>('WebKit.DOMPropertyNodeList', [ 'WebKit.DOMNodeList', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMRange(from_: GObject.Object) { return c<WebKit.DOMRange>('WebKit.DOMRange', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMScreen(from_: GObject.Object) { return c<WebKit.DOMScreen>('WebKit.DOMScreen', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMShadowRoot(from_: GObject.Object) { return c<WebKit.DOMShadowRoot>('WebKit.DOMShadowRoot', [ 'WebKit.DOMDocumentFragment', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMStorage(from_: GObject.Object) { return c<WebKit.DOMStorage>('WebKit.DOMStorage', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMStorageInfo(from_: GObject.Object) { return c<WebKit.DOMStorageInfo>('WebKit.DOMStorageInfo', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMStorageQuota(from_: GObject.Object) { return c<WebKit.DOMStorageQuota>('WebKit.DOMStorageQuota', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMStyleMedia(from_: GObject.Object) { return c<WebKit.DOMStyleMedia>('WebKit.DOMStyleMedia', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMStyleSheet(from_: GObject.Object) { return c<WebKit.DOMStyleSheet>('WebKit.DOMStyleSheet', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMStyleSheetList(from_: GObject.Object) { return c<WebKit.DOMStyleSheetList>('WebKit.DOMStyleSheetList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMText(from_: GObject.Object) { return c<WebKit.DOMText>('WebKit.DOMText', [ 'WebKit.DOMCharacterData', 'WebKit.DOMEventTarget', 'WebKit.DOMNode', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMTextTrack(from_: GObject.Object) { return c<WebKit.DOMTextTrack>('WebKit.DOMTextTrack', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMTextTrackCue(from_: GObject.Object) { return c<WebKit.DOMTextTrackCue>('WebKit.DOMTextTrackCue', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMTextTrackCueList(from_: GObject.Object) { return c<WebKit.DOMTextTrackCueList>('WebKit.DOMTextTrackCueList', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMTextTrackList(from_: GObject.Object) { return c<WebKit.DOMTextTrackList>('WebKit.DOMTextTrackList', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMTimeRanges(from_: GObject.Object) { return c<WebKit.DOMTimeRanges>('WebKit.DOMTimeRanges', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMTouch(from_: GObject.Object) { return c<WebKit.DOMTouch>('WebKit.DOMTouch', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMTrackEvent(from_: GObject.Object) { return c<WebKit.DOMTrackEvent>('WebKit.DOMTrackEvent', [ 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMTreeWalker(from_: GObject.Object) { return c<WebKit.DOMTreeWalker>('WebKit.DOMTreeWalker', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMUIEvent(from_: GObject.Object) { return c<WebKit.DOMUIEvent>('WebKit.DOMUIEvent', [ 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMValidityState(from_: GObject.Object) { return c<WebKit.DOMValidityState>('WebKit.DOMValidityState', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMVideoPlaybackQuality(from_: GObject.Object) { return c<WebKit.DOMVideoPlaybackQuality>('WebKit.DOMVideoPlaybackQuality', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMVideoTrack(from_: GObject.Object) { return c<WebKit.DOMVideoTrack>('WebKit.DOMVideoTrack', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMVideoTrackList(from_: GObject.Object) { return c<WebKit.DOMVideoTrackList>('WebKit.DOMVideoTrackList', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMWebKitNamedFlow(from_: GObject.Object) { return c<WebKit.DOMWebKitNamedFlow>('WebKit.DOMWebKitNamedFlow', [ 'WebKit.DOMObject', 'WebKit.DOMEventTarget', 'GObject.Object' ], from_) }
+export function WebKit_DOMWebKitPoint(from_: GObject.Object) { return c<WebKit.DOMWebKitPoint>('WebKit.DOMWebKitPoint', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMWheelEvent(from_: GObject.Object) { return c<WebKit.DOMWheelEvent>('WebKit.DOMWheelEvent', [ 'WebKit.DOMMouseEvent', 'WebKit.DOMUIEvent', 'WebKit.DOMEvent', 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMXPathExpression(from_: GObject.Object) { return c<WebKit.DOMXPathExpression>('WebKit.DOMXPathExpression', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMXPathNSResolver(from_: GObject.Object) { return c<WebKit.DOMXPathNSResolver>('WebKit.DOMXPathNSResolver', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_DOMXPathResult(from_: GObject.Object) { return c<WebKit.DOMXPathResult>('WebKit.DOMXPathResult', [ 'WebKit.DOMObject', 'GObject.Object' ], from_) }
+export function WebKit_Download(from_: GObject.Object) { return c<WebKit.Download>('WebKit.Download', [ 'GObject.Object' ], from_) }
+export function WebKit_FaviconDatabase(from_: GObject.Object) { return c<WebKit.FaviconDatabase>('WebKit.FaviconDatabase', [ 'GObject.Object' ], from_) }
+export function WebKit_FileChooserRequest(from_: GObject.Object) { return c<WebKit.FileChooserRequest>('WebKit.FileChooserRequest', [ 'GObject.Object' ], from_) }
+export function WebKit_GeolocationPolicyDecision(from_: GObject.Object) { return c<WebKit.GeolocationPolicyDecision>('WebKit.GeolocationPolicyDecision', [ 'GObject.Object' ], from_) }
+export function WebKit_HitTestResult(from_: GObject.Object) { return c<WebKit.HitTestResult>('WebKit.HitTestResult', [ 'GObject.Object' ], from_) }
+export function WebKit_IconDatabase(from_: GObject.Object) { return c<WebKit.IconDatabase>('WebKit.IconDatabase', [ 'GObject.Object' ], from_) }
+export function WebKit_NetworkRequest(from_: GObject.Object) { return c<WebKit.NetworkRequest>('WebKit.NetworkRequest', [ 'GObject.Object' ], from_) }
+export function WebKit_NetworkResponse(from_: GObject.Object) { return c<WebKit.NetworkResponse>('WebKit.NetworkResponse', [ 'GObject.Object' ], from_) }
+export function WebKit_SecurityOrigin(from_: GObject.Object) { return c<WebKit.SecurityOrigin>('WebKit.SecurityOrigin', [ 'GObject.Object' ], from_) }
+export function WebKit_SoupAuthDialog(from_: GObject.Object) { return c<WebKit.SoupAuthDialog>('WebKit.SoupAuthDialog', [ 'GObject.Object', 'Soup.SessionFeature' ], from_) }
+export function WebKit_ViewportAttributes(from_: GObject.Object) { return c<WebKit.ViewportAttributes>('WebKit.ViewportAttributes', [ 'GObject.Object' ], from_) }
+export function WebKit_WebBackForwardList(from_: GObject.Object) { return c<WebKit.WebBackForwardList>('WebKit.WebBackForwardList', [ 'GObject.Object' ], from_) }
+export function WebKit_WebDataSource(from_: GObject.Object) { return c<WebKit.WebDataSource>('WebKit.WebDataSource', [ 'GObject.Object' ], from_) }
+export function WebKit_WebDatabase(from_: GObject.Object) { return c<WebKit.WebDatabase>('WebKit.WebDatabase', [ 'GObject.Object' ], from_) }
+export function WebKit_WebFrame(from_: GObject.Object) { return c<WebKit.WebFrame>('WebKit.WebFrame', [ 'GObject.Object' ], from_) }
+export function WebKit_WebHistoryItem(from_: GObject.Object) { return c<WebKit.WebHistoryItem>('WebKit.WebHistoryItem', [ 'GObject.Object' ], from_) }
+export function WebKit_WebInspector(from_: GObject.Object) { return c<WebKit.WebInspector>('WebKit.WebInspector', [ 'GObject.Object' ], from_) }
+export function WebKit_WebNavigationAction(from_: GObject.Object) { return c<WebKit.WebNavigationAction>('WebKit.WebNavigationAction', [ 'GObject.Object' ], from_) }
+export function WebKit_WebPlugin(from_: GObject.Object) { return c<WebKit.WebPlugin>('WebKit.WebPlugin', [ 'GObject.Object' ], from_) }
+export function WebKit_WebPluginDatabase(from_: GObject.Object) { return c<WebKit.WebPluginDatabase>('WebKit.WebPluginDatabase', [ 'GObject.Object' ], from_) }
+export function WebKit_WebPolicyDecision(from_: GObject.Object) { return c<WebKit.WebPolicyDecision>('WebKit.WebPolicyDecision', [ 'GObject.Object' ], from_) }
+export function WebKit_WebResource(from_: GObject.Object) { return c<WebKit.WebResource>('WebKit.WebResource', [ 'GObject.Object' ], from_) }
+export function WebKit_WebSettings(from_: GObject.Object) { return c<WebKit.WebSettings>('WebKit.WebSettings', [ 'GObject.Object' ], from_) }
+export function WebKit_WebView(from_: GObject.Object) { return c<WebKit.WebView>('WebKit.WebView', [ 'Gtk.Container', 'Atk.ImplementorIface', 'Gtk.Buildable', 'Gtk.Scrollable', 'Gtk.Widget', 'GObject.InitiallyUnowned', 'GObject.Object' ], from_) }
+export function WebKit_WebWindowFeatures(from_: GObject.Object) { return c<WebKit.WebWindowFeatures>('WebKit.WebWindowFeatures', [ 'GObject.Object' ], from_) }
+export function AppIndicator3_Indicator(from_: GObject.Object) { return c<AppIndicator3.Indicator>('AppIndicator3.Indicator', [ 'GObject.Object' ], from_) }
+export function Notify_Notification(from_: GObject.Object) { return c<Notify.Notification>('Notify.Notification', [ 'GObject.Object' ], from_) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5066 @@
+{
+  "name": "ts-for-gjs",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@ava/babel-plugin-throws-helper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
+      "integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
+      "dev": true
+    },
+    "@ava/babel-preset-stage-4": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
+      "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "package-hash": "1.2.0"
+      },
+      "dependencies": {
+        "md5-hex": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "package-hash": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
+          "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0"
+          }
+        }
+      }
+    },
+    "@ava/babel-preset-transform-test-files": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
+      "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+      "dev": true,
+      "requires": {
+        "@ava/babel-plugin-throws-helper": "2.0.0",
+        "babel-plugin-espower": "2.3.2"
+      }
+    },
+    "@ava/pretty-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ava/pretty-format/-/pretty-format-1.1.0.tgz",
+      "integrity": "sha1-0KV9Jeua6rlkO90aAwZCuRwSPig=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "esutils": "2.0.2"
+      }
+    },
+    "@types/commander": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.9.2.tgz",
+      "integrity": "sha512-afS8cM8lIsjJjC9Cc40fa8pKUtRXrKTok3Ft/CUzxh/IF4N9zpoAfSr7HqLQwKZ2r7GvhmaogaiYGuhlrf2uhw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.43"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.74",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",
+      "integrity": "sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "7.0.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.43.tgz",
+      "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==",
+      "dev": true
+    },
+    "@types/xml2js": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.0.33.tgz",
+      "integrity": "sha1-IMXdZGAkUoTWSlVpABW5XkCft94=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "dev": true
+    },
+    "acorn-dynamic-import": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "2.1.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-exclude": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
+      "integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asn1.js": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "async": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "auto-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.1.0.tgz",
+      "integrity": "sha1-k7hk3H7gGjJigXddXHXKCnUeWWE=",
+      "dev": true
+    },
+    "ava": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-0.19.1.tgz",
+      "integrity": "sha1-Q92CQ1rRmzmA/8okiPBdqrlAsnM=",
+      "dev": true,
+      "requires": {
+        "@ava/babel-preset-stage-4": "1.1.0",
+        "@ava/babel-preset-transform-test-files": "3.0.0",
+        "@ava/pretty-format": "1.1.0",
+        "arr-flatten": "1.1.0",
+        "array-union": "1.0.2",
+        "array-uniq": "1.0.3",
+        "arrify": "1.0.1",
+        "auto-bind": "1.1.0",
+        "ava-init": "0.2.1",
+        "babel-code-frame": "6.26.0",
+        "babel-core": "6.26.0",
+        "bluebird": "3.5.0",
+        "caching-transform": "1.0.1",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "clean-stack": "1.3.0",
+        "clean-yaml-object": "0.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.0.0",
+        "cli-truncate": "1.1.0",
+        "co-with-promise": "4.6.0",
+        "code-excerpt": "2.1.0",
+        "common-path-prefix": "1.0.0",
+        "convert-source-map": "1.5.0",
+        "core-assert": "0.2.1",
+        "currently-unhandled": "0.4.1",
+        "debug": "2.6.8",
+        "diff": "3.3.0",
+        "diff-match-patch": "1.0.0",
+        "dot-prop": "4.2.0",
+        "empower-core": "0.6.2",
+        "equal-length": "1.0.1",
+        "figures": "2.0.0",
+        "find-cache-dir": "0.1.1",
+        "fn-name": "2.0.1",
+        "get-port": "3.2.0",
+        "globby": "6.1.0",
+        "has-flag": "2.0.0",
+        "hullabaloo-config-manager": "1.1.1",
+        "ignore-by-default": "1.0.1",
+        "indent-string": "3.2.0",
+        "is-ci": "1.0.10",
+        "is-generator-fn": "1.0.0",
+        "is-obj": "1.0.1",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "jest-diff": "19.0.0",
+        "jest-snapshot": "19.0.2",
+        "js-yaml": "3.9.1",
+        "last-line-stream": "1.0.0",
+        "lodash.debounce": "4.0.8",
+        "lodash.difference": "4.5.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.isequal": "4.5.0",
+        "loud-rejection": "1.6.0",
+        "matcher": "0.1.2",
+        "md5-hex": "2.0.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "ms": "0.7.3",
+        "multimatch": "2.1.0",
+        "observable-to-promise": "0.5.0",
+        "option-chain": "0.1.1",
+        "package-hash": "2.0.0",
+        "pkg-conf": "2.0.0",
+        "plur": "2.1.2",
+        "pretty-ms": "2.1.0",
+        "require-precompiled": "0.1.0",
+        "resolve-cwd": "1.0.0",
+        "slash": "1.0.0",
+        "source-map-support": "0.4.16",
+        "stack-utils": "1.0.1",
+        "strip-ansi": "3.0.1",
+        "strip-bom-buf": "1.0.0",
+        "supports-color": "3.2.3",
+        "time-require": "0.1.2",
+        "unique-temp-dir": "1.0.0",
+        "update-notifier": "2.2.0"
+      }
+    },
+    "ava-init": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
+      "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
+      "dev": true,
+      "requires": {
+        "arr-exclude": "1.0.0",
+        "execa": "0.7.0",
+        "has-yarn": "1.0.0",
+        "read-pkg-up": "2.0.0",
+        "write-pkg": "3.1.0"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-evaluate-path": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.2.0.tgz",
+      "integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg==",
+      "dev": true
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-flip-expressions": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.2.0.tgz",
+      "integrity": "sha512-rAsPA1pWBc7e2E6HepkP2e1sXugT+Oq/VCqhyuHJ8aJ2d/ifwnJfd4Qxjm21qlW43AN8tqaeByagKK6wECFMSw==",
+      "dev": true
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-is-nodes-equiv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
+      "dev": true
+    },
+    "babel-helper-is-void-0": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.2.0.tgz",
+      "integrity": "sha512-Axj1AYuD0E3Dl7nT3KxROP7VekEofz3XtEljzURf3fABalLpr8PamtgLFt+zuxtaCxRf9iuZmbAMMYWri5Bazw==",
+      "dev": true
+    },
+    "babel-helper-mark-eval-scopes": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.2.0.tgz",
+      "integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw==",
+      "dev": true
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-remove-or-void": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.2.0.tgz",
+      "integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA==",
+      "dev": true
+    },
+    "babel-helper-to-multiple-sequence-expressions": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.2.0.tgz",
+      "integrity": "sha512-ij9lpfdP3+Zc/7kNwa+NXbTrUlsYEWPwt/ugmQO0qflzLrveTIkbfOqQztvitk81aG5NblYDQXDlRohzu3oa8Q==",
+      "dev": true
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-minify-webpack-plugin": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-minify-webpack-plugin/-/babel-minify-webpack-plugin-0.2.0.tgz",
+      "integrity": "sha512-+5G5Qqm+DIVl7gY4rkHqlFRkaf1FZtz0imzu/Dy9+88AfOIuy7D5MQjkNgQr5gU6/YSZ+rImgxDqFcWkvvrjkQ==",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-preset-minify": "0.2.0",
+        "webpack-sources": "1.0.1"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-espower": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
+      "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.26.0",
+        "babylon": "6.18.0",
+        "call-matcher": "1.0.1",
+        "core-js": "2.5.0",
+        "espower-location-detector": "1.0.0",
+        "espurify": "1.7.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "babel-plugin-minify-builtins": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.2.0.tgz",
+      "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-constant-folding": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.2.0.tgz",
+      "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-dead-code-elimination": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.2.0.tgz",
+      "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0",
+        "babel-helper-mark-eval-scopes": "0.2.0",
+        "babel-helper-remove-or-void": "0.2.0",
+        "lodash.some": "4.6.0"
+      }
+    },
+    "babel-plugin-minify-flip-comparisons": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.2.0.tgz",
+      "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-is-void-0": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-guarded-expressions": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.2.0.tgz",
+      "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-flip-expressions": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-infinity": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.2.0.tgz",
+      "integrity": "sha512-U694vrla1lN6vDHWGrR832t3a/A2eh+kyl019LxEE2+sS4VTydyOPRsAOIYAdJegWRA4cMX1lm9azAN0cLIr8g==",
+      "dev": true
+    },
+    "babel-plugin-minify-mangle-names": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.2.0.tgz",
+      "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-mark-eval-scopes": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-numeric-literals": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.2.0.tgz",
+      "integrity": "sha512-VcLpb+r1YS7+RIOXdRsFVLLqoh22177USpHf+JM/g1nZbzdqENmfd5v534MLAbRErhbz6SyK+NQViVzVtBxu8g==",
+      "dev": true
+    },
+    "babel-plugin-minify-replace": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.2.0.tgz",
+      "integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q==",
+      "dev": true
+    },
+    "babel-plugin-minify-simplify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.2.0.tgz",
+      "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-flip-expressions": "0.2.0",
+        "babel-helper-is-nodes-equiv": "0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-type-constructors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.2.0.tgz",
+      "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
+      "dev": true,
+      "requires": {
+        "babel-helper-is-void-0": "0.2.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-inline-consecutive-adds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.2.0.tgz",
+      "integrity": "sha512-GlhOuLOQ28ua9prg0hT33HslCrEmz9xWXy9ZNZSACppCyRxxRW+haYtRgm7uYXCcd0q8ggCWD2pfWEJp5iiZfQ==",
+      "dev": true
+    },
+    "babel-plugin-transform-member-expression-literals": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.8.5.tgz",
+      "integrity": "sha512-Ux3ligf+ukzWaCbBYOstDuFBhRgMiJHlpJBKV4P47qtzVkd0lg1ddPj9fqIJqAM0n+CvxipyrZrnNnw3CdtQCg==",
+      "dev": true
+    },
+    "babel-plugin-transform-merge-sibling-variables": {
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.8.6.tgz",
+      "integrity": "sha512-o5Jioq553HtEAUN5uty7ELJMenXIxHI3PIs1yLqYWYQwP6mg6IPVAJ+U7i4zr9XGF/kb2RGsdehglGTV+vngqA==",
+      "dev": true
+    },
+    "babel-plugin-transform-minify-booleans": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.8.3.tgz",
+      "integrity": "sha512-bPbUhkeN2Nc0KH0/A19GwQGj8w+CvdJzyu8t59VoEDgsNMQ9Bopzi5DrVkrSsVjbYUaZpzq/DYLrH+wD5K2Tig==",
+      "dev": true
+    },
+    "babel-plugin-transform-property-literals": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.8.5.tgz",
+      "integrity": "sha512-MmiQsQ5AcIaRZMJD0zY5C4H3xuHm06/nWgtOsz7AXV44VEIXIlPiJ39IFYJ4Qx67/fEm8zJAedzR8t+B7d10Bg==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "babel-plugin-transform-regexp-constructors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.2.0.tgz",
+      "integrity": "sha512-7IsQ6aQx6LAaOqy97/PthTf+5Nx9grZww3r6E62IdWe76Yr8KsuwVjxzqSPQvESJqTE3EMADQ9S0RtwWDGNG9Q==",
+      "dev": true
+    },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.5.tgz",
+      "integrity": "sha512-uuCKvtweCyIvvC8fi92EcWRtO2Kt5KMNMRK6BhpDXdeb3sxvGM7453RSmgeu4DlKns3OlvY9Ep5Q9m5a7RQAgg==",
+      "dev": true
+    },
+    "babel-plugin-transform-remove-debugger": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.8.5.tgz",
+      "integrity": "sha512-InDQDdHPOLJKM+G6oXrEesf+P29QFBmcTXID+TAvZziVz+38xe2VO/Bn3FcRcRtnOOycbgsJkUNp9jIK+ist6g==",
+      "dev": true
+    },
+    "babel-plugin-transform-remove-undefined": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.2.0.tgz",
+      "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0"
+      }
+    },
+    "babel-plugin-transform-simplify-comparison-operators": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.8.5.tgz",
+      "integrity": "sha512-B3HlBZb+Uq86nRj5yNPO6pJ3noEdqHvzYkEYoUWtrsWTv48ZIRatYlumoOiif/v8llF13YjYjx9zhyznDx+N9g==",
+      "dev": true
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-undefined-to-void": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.3.tgz",
+      "integrity": "sha512-goYwp8dMrzHD6x9GjZ2M85Mk2vxf1h85CnUgAjfftUnlJvzF4uj5MrbReHBTbjQ96C8CuRzvhYZ3tv8H3Sc1ZA==",
+      "dev": true
+    },
+    "babel-preset-minify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz",
+      "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-minify-builtins": "0.2.0",
+        "babel-plugin-minify-constant-folding": "0.2.0",
+        "babel-plugin-minify-dead-code-elimination": "0.2.0",
+        "babel-plugin-minify-flip-comparisons": "0.2.0",
+        "babel-plugin-minify-guarded-expressions": "0.2.0",
+        "babel-plugin-minify-infinity": "0.2.0",
+        "babel-plugin-minify-mangle-names": "0.2.0",
+        "babel-plugin-minify-numeric-literals": "0.2.0",
+        "babel-plugin-minify-replace": "0.2.0",
+        "babel-plugin-minify-simplify": "0.2.0",
+        "babel-plugin-minify-type-constructors": "0.2.0",
+        "babel-plugin-transform-inline-consecutive-adds": "0.2.0",
+        "babel-plugin-transform-member-expression-literals": "6.8.5",
+        "babel-plugin-transform-merge-sibling-variables": "6.8.6",
+        "babel-plugin-transform-minify-booleans": "6.8.3",
+        "babel-plugin-transform-property-literals": "6.8.5",
+        "babel-plugin-transform-regexp-constructors": "0.2.0",
+        "babel-plugin-transform-remove-console": "6.8.5",
+        "babel-plugin-transform-remove-debugger": "6.8.5",
+        "babel-plugin-transform-remove-undefined": "0.2.0",
+        "babel-plugin-transform-simplify-comparison-operators": "6.8.5",
+        "babel-plugin-transform-undefined-to-void": "6.8.3",
+        "lodash.isplainobject": "4.0.6"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.0",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.16"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.0",
+        "regenerator-runtime": "0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "dev": true
+    },
+    "big.js": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+      "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
+    },
+    "boxen": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+      "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.1.0",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.2",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "1.0.6",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.2"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.5"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "dev": true,
+      "requires": {
+        "pako": "0.2.9"
+      }
+    },
+    "buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+      "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "caching-transform": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+      "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+      "dev": true,
+      "requires": {
+        "md5-hex": "1.3.0",
+        "mkdirp": "0.5.1",
+        "write-file-atomic": "1.3.4"
+      },
+      "dependencies": {
+        "md5-hex": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        }
+      }
+    },
+    "call-matcher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
+      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.0",
+        "deep-equal": "1.0.1",
+        "espurify": "1.7.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "call-signature": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
+    },
+    "ci-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "clean-stack": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+      "dev": true
+    },
+    "clean-yaml-object": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+      "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.0.0.tgz",
+      "integrity": "sha1-75h+09SDkaw9q5GAtAanQhgNbmo=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
+      "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "co-with-promise": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
+      "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "1.0.0"
+      }
+    },
+    "code-excerpt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
+      "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
+      "dev": true,
+      "requires": {
+        "convert-to-spaces": "1.0.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "common-path-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
+      "integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "configstore": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "dev": true
+    },
+    "convert-to-spaces": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+      "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
+      "dev": true
+    },
+    "core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+      "dev": true,
+      "requires": {
+        "buf-compare": "1.0.1",
+        "is-error": "2.2.1"
+      }
+    },
+    "core-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
+      }
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.13",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.30"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "date-time": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
+      "integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "diff": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
+      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+      "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "dev": true
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "empower-core": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
+      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+      "dev": true,
+      "requires": {
+        "call-signature": "0.0.2",
+        "core-js": "2.5.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
+      }
+    },
+    "equal-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
+      "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.0.2.tgz",
+      "integrity": "sha1-7sXHJurO9Rt/a3PCDbbhsTsGnJg=",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "espower-location-detector": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
+      "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+      "dev": true,
+      "requires": {
+        "is-url": "1.2.2",
+        "path-is-absolute": "1.0.1",
+        "source-map": "0.5.7",
+        "xtend": "4.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "espurify": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.30"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
+      "integrity": "sha512-ni0r0lrm7AOzsh2qC5mi9sj8S0gmj5fLNjfFpxN05FB4tAVZEKotbkjOtLPqTCX/CXT7NsUr6juZb4IFJeNNdA==",
+      "dev": true,
+      "requires": {
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
+      }
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "find-cache-dir": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+      "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "2.0.0"
+      }
+    },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        }
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "has-yarn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
+      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+      "dev": true
+    },
+    "hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "dev": true
+    },
+    "hullabaloo-config-manager": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
+      "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "4.2.0",
+        "es6-error": "4.0.2",
+        "graceful-fs": "4.1.11",
+        "indent-string": "3.2.0",
+        "json5": "0.5.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.clonedeepwith": "4.5.0",
+        "lodash.isequal": "4.5.0",
+        "lodash.merge": "4.6.0",
+        "md5-hex": "2.0.0",
+        "package-hash": "2.0.0",
+        "pkg-dir": "2.0.0",
+        "resolve-from": "3.0.0",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        }
+      }
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "dev": true
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "irregular-plurals": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
+      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.10.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.0.0"
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-error": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
+      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-url": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "jest-diff": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-19.0.0.tgz",
+      "integrity": "sha1-0VY8/FbItgIymI+8BdTRbtkPBjw=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "diff": "3.3.0",
+        "jest-matcher-utils": "19.0.0",
+        "pretty-format": "19.0.0"
+      }
+    },
+    "jest-file-exists": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-file-exists/-/jest-file-exists-19.0.0.tgz",
+      "integrity": "sha1-zKLlh6EeyS4kz+qz+KlNZX8/zrg=",
+      "dev": true
+    },
+    "jest-matcher-utils": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz",
+      "integrity": "sha1-Xs2bY1ZdKwAfYfv37Ex/U3lkVk0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "pretty-format": "19.0.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-19.0.0.tgz",
+      "integrity": "sha1-cheWuJwOTXYWBvm6jLgoo7YkZBY=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "micromatch": "2.3.11"
+      }
+    },
+    "jest-mock": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-19.0.0.tgz",
+      "integrity": "sha1-ZwOGQelgerLOCOxKjLg6q7yJnQE=",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-19.0.2.tgz",
+      "integrity": "sha1-nBshYhT3GHw4v9XHCx76sWsP9Qs=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "jest-diff": "19.0.0",
+        "jest-file-exists": "19.0.0",
+        "jest-matcher-utils": "19.0.0",
+        "jest-util": "19.0.2",
+        "natural-compare": "1.4.0",
+        "pretty-format": "19.0.0"
+      }
+    },
+    "jest-util": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-19.0.2.tgz",
+      "integrity": "sha1-4KAjKiq55rK1Nmi9s1NMK1l37UE=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "graceful-fs": "4.1.11",
+        "jest-file-exists": "19.0.0",
+        "jest-message-util": "19.0.0",
+        "jest-mock": "19.0.0",
+        "jest-validate": "19.0.2",
+        "leven": "2.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
+    "jest-validate": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-19.0.2.tgz",
+      "integrity": "sha1-3FNN9fEnjVtj3zKxQkHU2/ckTAw=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "jest-matcher-utils": "19.0.0",
+        "leven": "2.1.0",
+        "pretty-format": "19.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
+    },
+    "json-loader": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
+    },
+    "last-line-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
+      "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
+      "dev": true,
+      "requires": {
+        "through2": "2.0.3"
+      }
+    },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "4.0.1"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "loader-runner": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
+      "requires": {
+        "big.js": "3.1.3",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.clonedeepwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
+      "integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+      "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "matcher": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-0.1.2.tgz",
+      "integrity": "sha1-7yDL3mTCTFDMYa9bg+4LG4/wAQE=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "md5-hex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+      "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+      "dev": true,
+      "requires": {
+        "md5-o-matic": "0.1.1"
+      }
+    },
+    "md5-o-matic": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+      "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "dev": true,
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "hash-base": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+      "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+      "dev": true
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node-libs-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+      "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+      "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.3",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dependencies": {
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "2.0.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "observable-to-promise": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
+      "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+      "dev": true,
+      "requires": {
+        "is-observable": "0.2.0",
+        "symbol-observable": "1.0.4"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+          "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+          "dev": true
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "option-chain": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/option-chain/-/option-chain-0.1.1.tgz",
+      "integrity": "sha1-6bgR4AbxwPVIAvKClb/Ilw+Nz70=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1"
+      }
+    },
+    "os-browserify": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+      "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
+    },
+    "package-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+      "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "lodash.flattendeep": "4.4.0",
+        "md5-hex": "2.0.0",
+        "release-zalgo": "1.0.0"
+      }
+    },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.4.1"
+      }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "dev": true,
+      "requires": {
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.0.6",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.2",
+        "pbkdf2": "3.0.13"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "pbkdf2": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+      "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+      "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+      "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+      "dev": true,
+      "requires": {
+        "pinkie": "1.0.0"
+      }
+    },
+    "pkg-conf": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
+      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "load-json-file": "2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        }
+      }
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "1.3.0"
+      }
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+      "integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        }
+      }
+    },
+    "pretty-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2",
+        "parse-ms": "1.0.1",
+        "plur": "1.0.0"
+      },
+      "dependencies": {
+        "plur": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+          "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
+          "dev": true
+        }
+      }
+    },
+    "private": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "prr": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        }
+      }
+    },
+    "randombytes": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "rc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        }
+      }
+    },
+    "regenerate": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
+    },
+    "regex-cache": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.1"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "4.0.2"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-precompiled": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
+      "integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
+      "dev": true
+    },
+    "resolve-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
+      "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "2.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "dev": true,
+      "requires": {
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-list-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
+      "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "dev": true
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stream-http": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        }
+      }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
+    },
+    "tapable": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+      "dev": true
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "time-require": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
+      "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
+      "dev": true,
+      "requires": {
+        "chalk": "0.4.0",
+        "date-time": "0.1.1",
+        "pretty-ms": "0.2.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
+          }
+        },
+        "parse-ms": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+          "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+          "dev": true
+        },
+        "pretty-ms": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+          "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+          "dev": true,
+          "requires": {
+            "parse-ms": "0.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
+      }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "ts-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-2.3.4.tgz",
+      "integrity": "sha512-OTFLRAX5LdIbdB9VOBzgdF4/FubWnZUTbxaAZeN70TvMCFVeaRIWcLGGvowlKwpObNih9KDScWYmLnYzDL2P7A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.1.0",
+        "enhanced-resolve": "3.4.1",
+        "loader-utils": "1.1.0",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "uglifyjs-webpack-plugin": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+      "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-js": "2.8.29",
+        "webpack-sources": "1.0.1"
+      }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+      "dev": true
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "1.0.0"
+      }
+    },
+    "unique-temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
+      "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "os-tmpdir": "1.0.2",
+        "uid2": "0.0.3"
+      }
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+      "dev": true,
+      "requires": {
+        "boxen": "1.2.1",
+        "chalk": "1.1.3",
+        "configstore": "3.1.1",
+        "import-lazy": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
+      }
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "watchpack": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+      "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "webpack": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.5.tgz",
+      "integrity": "sha512-qeUx4nIbeLL53qqNTs3kObPBMkUVDrOjEfp/hTvMlx21qL2MsGNr8/tXCoX/lS12dLl9qtZaXv2qfBEctPScDg==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "5.2.2",
+        "ajv-keywords": "2.1.0",
+        "async": "2.5.0",
+        "enhanced-resolve": "3.4.1",
+        "escope": "3.6.0",
+        "interpret": "1.0.3",
+        "json-loader": "0.5.7",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.0.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.2.1",
+        "tapable": "0.2.8",
+        "uglifyjs-webpack-plugin": "0.4.6",
+        "watchpack": "1.4.0",
+        "webpack-sources": "1.0.1",
+        "yargs": "8.0.2"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "webpack-sources": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
+      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "dev": true,
+      "requires": {
+        "source-list-map": "2.0.0",
+        "source-map": "0.5.7"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "write-json-file": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.2.0.tgz",
+      "integrity": "sha1-UYYlBruzthnu+reFnx/WxtBTCHY=",
+      "dev": true,
+      "requires": {
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "pify": "2.3.0",
+        "sort-keys": "1.1.2",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+          "dev": true
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+          "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        }
+      }
+    },
+    "write-pkg": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
+      "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
+      "dev": true,
+      "requires": {
+        "sort-keys": "2.0.0",
+        "write-json-file": "2.2.0"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "read-pkg-up": "2.0.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "7.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tsc test.ts && node_modules/ava/cli.js test.js",
-    "regress": "tsc main.ts && nodejs main.js -m Gtk-3.0 -m Soup-2.4 -m GtkSource-3.0 -m WebKit-3.0 -m AppIndicator3-0.1 -m Notify-0.7 -o out && cd out && tsc sam.ts",
+    "regress": "tsc main.ts && node main.js -m Gtk-3.0 -m Soup-2.4 -m GtkSource-3.0 -m WebKit-3.0 -m AppIndicator3-0.1 -m Notify-0.7 -o out && cd out && tsc sam.ts",
     "build": "tsc main.ts",
     "watch": "tsc --watch",
     "run": "node main.js"
@@ -26,6 +26,7 @@
     "@types/node": "^7.0.31",
     "@types/xml2js": "0.0.33",
     "ava": "^0.19.1",
+    "babel-minify-webpack-plugin": "^0.2.0",
     "commander": "^2.9.0",
     "events": "^1.1.1",
     "ts-loader": "^2.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */                       
     "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
+    "module": "esnext",                       /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
     // "lib": [],                             /* Specify library files to be included in the compilation:  */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
This changes API for runtime-checking casts to allow for tree-shaking it.

## size comparison for editor example

|           | old  | new  |
|-----------|------|------|
| no minify | 75.9kiB | 148kiB  |
| minify    | 66.4kiB | 1.51kiB |

In this PR I also updated generated definitions in out directory and added package-lock.json generated by npm 5.
I also updated examples to match newly generated bindings.