### PR TITLE
Initialize GirRepository.ns to get rid of warning

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -160,7 +160,7 @@ export class GirModule {
     dependencies: string[] = []
     transitiveDependencies: string[] = []
     repo: GirRepository
-    ns: GirNamespace
+    ns: GirNamespace = { $: { name: "", version: "" } }
     symTable: { [key:string]: any } = {}
     patch: { [key:string]: string[] } = {}
 


### PR DESCRIPTION
When editing main.ts vim flagged an error about GirRepository.ns possibly not being initialized. That got on my nerves so I got rid of it by adding a minimalist initializer, which seemed to be the most efficient fix.