### PR TITLE
connect methods return a number

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -726,7 +726,7 @@ export class GirModule {
         let [params, outParams] = this.getParameters(e.parameters, outArrayLengthIndex)
         let paramComma = params.length > 0 ? ', ' : ''
 
-        return [`    connect(sigName: "${sigName}", callback: ((obj: ${clsName}${paramComma}${params}) => ${retType})): void`]
+        return [`    connect(sigName: "${sigName}", callback: ((obj: ${clsName}${paramComma}${params}) => ${retType})): number`]
     }
 
     exportFunction(e: GirFunction) {
@@ -960,9 +960,9 @@ export class GirModule {
             let prefix = "GObject."
             if (this.name == "GObject") prefix = ""
             for (let p of propertyNames) {
-                def.push(`    connect(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): void`)
+                def.push(`    connect(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): number`)
             }
-            def.push(`    connect(sigName: string, callback: any): void`)
+            def.push(`    connect(sigName: string, callback: any): number`)
         }
 
         // TODO: Records have fields


### PR DESCRIPTION
Signal connect methods return a number which can be used as a reference for disconnect methods, but ts-for-gjs was generating signatures that returned void.