### PR TITLE
Signal methods

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -963,9 +963,9 @@ export class GirModule {
             let prefix = "GObject."
             if (this.name == "GObject") prefix = ""
             for (let p of propertyNames) {
-                def.push(`    connect(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): void`)
+                def.push(`    connect(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): number`)
             }
-            def.push(`    connect(sigName: string, callback: any): void`)
+            def.push(`    connect(sigName: string, callback: any): number`)
             def.push(`    connect_after(sigName: string, callback: any): number`)
             def.push(`    emit(sigName: string, ...args: any[]): void`)
             def.push(`    disconnect(id: number): void`)

--- a/main.ts
+++ b/main.ts
@@ -964,6 +964,7 @@ export class GirModule {
             if (this.name == "GObject") prefix = ""
             for (let p of propertyNames) {
                 def.push(`    connect(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): number`)
+                def.push(`    connect_after(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): number`)
             }
             def.push(`    connect(sigName: string, callback: any): number`)
             def.push(`    connect_after(sigName: string, callback: any): number`)

--- a/main.ts
+++ b/main.ts
@@ -726,7 +726,10 @@ export class GirModule {
         let [params, outParams] = this.getParameters(e.parameters, outArrayLengthIndex)
         let paramComma = params.length > 0 ? ', ' : ''
 
-        return [`    connect(sigName: "${sigName}", callback: ((obj: ${clsName}${paramComma}${params}) => ${retType})): void`]
+         return [`    connect(sigName: "${sigName}", callback: ((obj: ${clsName}${paramComma}${params}) => ${retType})): number`,
+            `    connect_after(sigName: "${sigName}", callback: ((obj: ${clsName}${paramComma}${params}) => ${retType})): number`,
+            `    emit(sigName: "${sigName}"${paramComma}${params}): void`
+         ]
     }
 
     exportFunction(e: GirFunction) {
@@ -963,6 +966,9 @@ export class GirModule {
                 def.push(`    connect(sigName: "notify::${p}", callback: ((obj: ${name}, pspec: ${prefix}ParamSpec) => void)): void`)
             }
             def.push(`    connect(sigName: string, callback: any): void`)
+            def.push(`    connect_after(sigName: string, callback: any): number`)
+            def.push(`    emit(sigName: string, ...args: any[]): void`)
+            def.push(`    disconnect(id: number): void`)
         }
 
         // TODO: Records have fields


### PR DESCRIPTION
[According to the gks wiki](https://gitlab.gnome.org/GNOME/gjs/wikis/Mapping#signals) GObjects have methods for signals, but these were missing from ts-for-gjs' output, so I've added them.

Sorry this can't be merged cleanly. I think it's because I originally added this to the wrong branch, and tried to patch it into a clean branch from upstream afterwards, but something seems to have gone wrong. If it's a problem I'll try doing it over again.