### PR TITLE
Fix GType and add $gtype properties

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1138,7 +1138,14 @@ export class GirModule {
 
         if (this.ns.alias)
             for (let e of this.ns.alias)
-                out = out.concat(this.exportAlias(e))
+                // GType is not a number in GJS
+                if (this.name != "GObject" || e.$.name != "Type")
+                    out = out.concat(this.exportAlias(e))
+
+        if (this.name == "GObject")
+            out = out.concat(["export interface Type {",
+                "    name: string",
+                "}"])
 
         outStream.write(out.join("\n"))
     }

--- a/main.ts
+++ b/main.ts
@@ -1022,6 +1022,9 @@ export class GirModule {
             }
         }
 
+        if (isDerivedFromGObject)
+            def.push(`    static $gtype: ${this.name == "GObject" ? "" : "GObject."}Type`)
+
         def.push("}")
 
         return def


### PR DESCRIPTION
Consulting the [wkik](https://gitlab.gnome.org/GNOME/gjs/wikis/Mapping#gtype-objects) I found that in gjs GType is not represented as a number, but an object with a `name` field; its numeric value is not made public. Classes should have a `static $gtype: Object.GType` member so one can read their type.