### PR TITLE
Export symbols used by registerClass

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1119,11 +1119,11 @@ export class GirModule {
     Children?: string[],
     InternalChildren?: string[]
 }`,
-"export GTypeName: symbol",
-"export requires: symbol",
-"export interfaces: symbol",
-"export properties: symbol",
-"export signals: symbol",
+"export const GTypeName: symbol",
+"export const requires: symbol",
+"export const interfaces: symbol",
+"export const properties: symbol",
+"export const signals: symbol",
 "export function registerClass(metaInfo: MetaInfo, klass: Function): Function",
 "export function registerClass(klass: Function): Function",
 "export function registerClass<T extends MetaInfo | Function>(a: T, b?: Function): Function"])

--- a/main.ts
+++ b/main.ts
@@ -1119,6 +1119,11 @@ export class GirModule {
     Children?: string[],
     InternalChildren?: string[]
 }`,
+"export GTypeName: symbol",
+"export requires: symbol",
+"export interfaces: symbol",
+"export properties: symbol",
+"export signals: symbol",
 "export function registerClass(metaInfo: MetaInfo, klass: Function): Function",
 "export function registerClass(klass: Function): Function",
 "export function registerClass<T extends MetaInfo | Function>(a: T, b?: Function): Function"])


### PR DESCRIPTION
For some reason these got missed from my earlier PR(s). These symbols are currently only used by registerClass internally, but they are exported by gjs' Object module and could be useful for a proposed decorator-based replacement for registerClass.