### PR TITLE
package.json: add ts-node as devDep to fix running in-tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@typescript-eslint/parser": "^2.20.0",
     "ava": "^3.3.0",
     "ejs": "^3.0.1",
+    "ts-node": "^8.10.2",
     "typescript": "^3.8.2"
   },
   "dependencies": {


### PR DESCRIPTION
When oclif detects src/-lib/ split, it'll try to use .ts files in src/
directly. If ts-node isn't installed, it'll fail and won't re-try the
file in lib/, thus failing the run entirely.

Add ts-node as a devDep fixes the issue and allow the command to run
directly in-tree.