### PR TITLE
template: improve typing for cast.ts

### DIFF
--- a/examples/Gjs/editor/main.ts
+++ b/examples/Gjs/editor/main.ts
@@ -16,7 +16,7 @@ srcView.monospace = true
 
 // Unfortunately the "buffer" property is not GtkSource.Buffer so we need to downcast
 // it. giCast gives us a type-check at runtime.
-const buf: GtkSource.Buffer = giCast<GtkSource.Buffer>(srcView.buffer, GtkSource.Buffer)
+const buf = giCast(srcView.buffer, GtkSource.Buffer)
 const lang = GtkSource.LanguageManager.get_default().get_language('js')
 print('lang', lang)
 buf.set_language(lang)

--- a/templates/Gjs/cast.ts
+++ b/templates/Gjs/cast.ts
@@ -1,6 +1,6 @@
 import * as GObject from './GObject-2.0';
 
-const inheritanceTable = {
+const inheritanceTable: { [key: string]: string[] } = {
 <% for (const key of inheritanceTableKeys) { -%>
     '<%= key %>': [
     <% for (const value of inheritanceTable[key]) { -%>
@@ -11,7 +11,8 @@ const inheritanceTable = {
 }
 
 
-interface StaticNamed {
+interface StaticNamedClass<T> {
+    new (...args: any[]): T
     name: string
 }
 
@@ -20,7 +21,7 @@ interface StaticNamed {
  * and raising an exception if the cast fails. Allows casting to implemented
  * interfaces, too.
  */
-export function giCast<T>(from_: GObject.Object, to_: StaticNamed): T {
+export function giCast<T>(from_: GObject.Object, to_: StaticNamedClass<T>): T {
     const desc: string = from_.toString()
     let clsName: string|null = null
     for (const k of desc.split(" ")) {
@@ -35,7 +36,7 @@ export function giCast<T>(from_: GObject.Object, to_: StaticNamed): T {
         return ((from_ as any) as T)
 
     if (clsName) {
-        const parents = (inheritanceTable as any)[clsName]
+        const parents = inheritanceTable[clsName]
         if (parents) {
             if (parents.indexOf(toName) >= 0)
                 return ((from_ as any) as T)


### PR DESCRIPTION
The first improvement is typing `inheritanceTable` as indexable, which
enables us not to cast it to `any` needlessly, improving type safely.

The second improvement is making `StaticNamed` interface a generic and
adding construct signature. This way, TypeScript will be able to infer
the type parameter of `giCast`, which allow users to write:
```js
const buf = giCast(srcView.buffer, GtkSource.Buffer)
```
without writing the type twice.