### PR TITLE
template: uses <%_ to fix indent of node-gtk's index.d.ts

### DIFF
--- a/templates/node-gtk/index.d.ts
+++ b/templates/node-gtk/index.d.ts
@@ -1,22 +1,22 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
-<% for (const girModule of girModules) { -%>
-    <% if (buildType === 'lib') { -%>
+<%_ for (const girModule of girModules) { _%>
+    <%_ if (buildType === 'lib') { _%>
         import * as <%= girModule.name %> from './<%= girModule.packageName %>';
-    <% } -%>
-    <% if (buildType === 'types') { -%>
+    <%_ } _%>
+    <%_ if (buildType === 'types') { _%>
 /// <reference path="<%= girModule.packageName %>.d.ts" />
-    <% } -%>
-<% } -%>
+    <%_ } _%>
+<%_ } _%>
 
-<% if (buildType === 'types') { -%>
+<%_ if (buildType === 'types') { _%>
 declare module 'node-gtk' {
-<% } -%>
+<%_ } _%>
     export function require(ns: string, ver?: string): any;
-    <% for (const girModule of girModules) { -%>
+    <%_ for (const girModule of girModules) { _%>
         export function require(ns: '<%= girModule.name %>'): typeof <%= girModule.name %>;
         export function require(ns: '<%= girModule.name %>', ver?: '<%= girModule.version %>'): typeof <%= girModule.name %>;
-    <% } -%>
+    <%_ } _%>
     export function startLoop(): void;
-<% if (buildType === 'types') { -%>
+<%_ if (buildType === 'types') { _%>
 }
-<% } -%>
+<%_ } _%>


### PR DESCRIPTION
Without <%_, the preceeding space won't be removed and will be included
in front of any following line. This has significance when outputing
`// <reference` line, as TS (at least in VSCode) won't read the line if
it's indented at all.