### PR TITLE
Add the type for ex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ if (require.main === module) {
                 console.log(error)
                 require('@oclif/errors/handle')(error)
             })
-    } catch (ex) {
+    } catch (ex: any) {
         console.log(ex.stack)
     }
 }


### PR DESCRIPTION
... to avoid the type-unknown error during installation.