### PR TITLE
[node-gtk] don't add $obj parameter in connect() method either

### DIFF
--- a/src/template-processor.ts
+++ b/src/template-processor.ts
@@ -100,14 +100,16 @@ export class TemplateProcessor {
     ) {
         const ident = this.generateIndent(identCount)
         const def: string[] = []
+
+        const objParam = this.config.environment === 'node' ? '' : `$obj: ${clsName}${paramComma}`
         def.push(
-            `${ident}connect(sigName: "${sigName}", callback: (($obj: ${clsName}${paramComma}${params.join(
+            `${ident}connect(sigName: "${sigName}", callback: ((${objParam}${params.join(
                 ', ',
             )}) => ${retType})): number`,
         )
         if (this.config.environment === 'gjs') {
             def.push(
-                `${ident}connect_after(sigName: "${sigName}", callback: (($obj: ${clsName}${paramComma}${params.join(
+                `${ident}connect_after(sigName: "${sigName}", callback: ((${objParam}${params.join(
                     ', ',
                 )}) => ${retType})): number`,
             )


### PR DESCRIPTION
I used connect() in node-gtk, and there it doesn't pass $obj to the
callback either. Besides, node-gtk's connect wrapper passes the callback
to connect() as-is [1], so the callback signature shouldn't be
different.

This change is also propagated to notify signal methods too, by consolidating
the notify signal method generation with the normal notify signal method generation. This has a small side-effect on node-gtk; see the commit message.

[1]
https://github.com/romgrk/node-gtk/blob/3051382de16bf730716248087137f5cb611d9923/lib/bootstrap.js#L60